### PR TITLE
make cases for lowstar_endianness consistent

### DIFF
--- a/krmllib/dist/generic/fstar_uint128_gcc64.h
+++ b/krmllib/dist/generic/fstar_uint128_gcc64.h
@@ -25,7 +25,7 @@
 
 #include "FStar_UInt128.h"
 #include "FStar_UInt_8_16_32_64.h"
-#include "LowStar_Endianness.h"
+#include "lowstar_endianness.h"
 
 /* GCC + using native unsigned __int128 support */
 

--- a/krmllib/dist/generic/lowstar_endianness.h
+++ b/krmllib/dist/generic/lowstar_endianness.h
@@ -11,10 +11,8 @@
 
 #include "FStar_UInt128.h"
 #include <inttypes.h>
-#include <stdbool.h>
+#include "krmllib.h"
 #include "krml/internal/compat.h"
-#include "krml/lowstar_endianness.h"
-#include "krml/internal/types.h"
 #include "krml/internal/target.h"
 static inline void store128_le(uint8_t *x0, FStar_UInt128_uint128 x1);
 
@@ -27,3 +25,4 @@ static inline FStar_UInt128_uint128 load128_be(uint8_t *x0);
 
 #define __LowStar_Endianness_H_DEFINED
 #endif
+diff --git a/krmllib/dist/generic/LowStar_Endianness.h b/krmllib/dist/generic/LowStar_Endianness.h

--- a/krmllib/dist/minimal/Makefile.include
+++ b/krmllib/dist/minimal/Makefile.include
@@ -2,4 +2,4 @@ USER_TARGET=libkrmllib.a
 USER_CFLAGS=
 USER_C_FILES=fstar_uint128.c
 ALL_C_FILES=
-ALL_H_FILES=FStar_UInt128.h FStar_UInt_8_16_32_64.h LowStar_Endianness.h
+ALL_H_FILES=FStar_UInt128.h FStar_UInt_8_16_32_64.h lowstar_endianness.h

--- a/krmllib/dist/minimal/fstar_uint128_gcc64.h
+++ b/krmllib/dist/minimal/fstar_uint128_gcc64.h
@@ -25,7 +25,7 @@
 
 #include "FStar_UInt128.h"
 #include "FStar_UInt_8_16_32_64.h"
-#include "LowStar_Endianness.h"
+#include "lowstar_endianness.h"
 
 /* GCC + using native unsigned __int128 support */
 

--- a/krmllib/dist/minimal/lowstar_endianness.h
+++ b/krmllib/dist/minimal/lowstar_endianness.h
@@ -11,8 +11,10 @@
 
 #include "FStar_UInt128.h"
 #include <inttypes.h>
-#include "krmllib.h"
+#include <stdbool.h>
 #include "krml/internal/compat.h"
+#include "krml/lowstar_endianness.h"
+#include "krml/internal/types.h"
 #include "krml/internal/target.h"
 static inline void store128_le(uint8_t *x0, FStar_UInt128_uint128 x1);
 
@@ -25,3 +27,4 @@ static inline FStar_UInt128_uint128 load128_be(uint8_t *x0);
 
 #define __LowStar_Endianness_H_DEFINED
 #endif
+diff --git a/krmllib/dist/minimal/LowStar_Endianness.h b/krmllib/dist/minimal/LowStar_Endianness.h


### PR DESCRIPTION
I don't mind which version to use but the warnings about this are annoying, let's decide on a casing.