### PR TITLE
Fixup the interaction of CAbstractStruct, abstract types, and polymorphic equalities

### DIFF
--- a/src/Monomorphization.ml
+++ b/src/Monomorphization.ml
@@ -429,6 +429,18 @@ let equalities files =
         equalities @ [ d ]
       ) decls
 
+    method private maybe_by_addr head x y =
+      let t_op, x, y =
+        match x.typ with
+        | TQualified lid when Hashtbl.find_opt types_map lid = Some Forward ->
+            let t = TBuf (x.typ, true) in
+            TArrow (t, TArrow (t, TBool)), with_type t (EAddrOf x), with_type t (EAddrOf y)
+        | _ ->
+            let t = x.typ in
+            TArrow (t, TArrow (t, TBool)), x, y
+      in
+      EApp (with_type t_op head, [x;y])
+
     (* For type [t] and either [op = Eq] or [op = Neq], generate a recursive
      * equality predicate that implements F*'s structural equality. *)
     method private generate_equality t op =
@@ -437,10 +449,32 @@ let equalities files =
         | K.PEq -> [], "__eq"
         | K.PNeq -> [], "__neq"
       in
-      let eq_typ = TArrow (t, TArrow (t, TBool)) in
       let instance_lid = Gen.gen_lid eq_lid [ t ] in
       let x = fresh_binder "x" t in
       let y = fresh_binder "y" t in
+
+      (* Generate an external to stand in for a user-provided equality operator
+         for an external type. *)
+      let gen_poly ?(pointer=false) () =
+        let t' = if pointer then TBuf (t, true) else t in
+        let eq_typ' = TArrow (t', TArrow (t', TBool)) in
+        match op with
+        | K.PNeq ->
+            (* let __neq__t x y = not (__eq__t x y) *)
+            let def () =
+              let body = mk_not (with_type TBool (
+                EApp (with_type eq_typ' (self#generate_equality t K.PEq), [
+                  with_type t' (EBound 0); with_type t' (EBound 1) ])))
+              in
+              DFunction (None, [], 0, TBool, instance_lid, [ y; x ], body)
+            in
+            EQualified (Gen.register_def current_file eq_lid [ t ] instance_lid def)
+        | K.PEq ->
+            (* assume val __eq__t: t -> t -> bool *)
+            let def () = DExternal (None, [], instance_lid, eq_typ', [ "x"; "y" ]) in
+            EQualified (Gen.register_def current_file eq_lid [ t ] instance_lid def)
+      in
+
 
       match t with
       | TQualified ([ "Prims" ], ("int" | "nat" | "pos")) ->
@@ -489,17 +523,23 @@ let equalities files =
                   with_type TBool (EBool true)
               | _ ->
                   with_type TBool (
-                    EApp (
-                      with_type (TArrow (t, TArrow (t, TBool))) (
-                        self#generate_equality t op), [
-                        with_type t e1;
-                        with_type t e2]))
+                    self#maybe_by_addr (self#generate_equality t op) (with_type t e1) (with_type t e2))
             in
             match Hashtbl.find types_map lid with
-            | Abbrev _ | Enum _ | Union _ | Forward ->
+            | Abbrev _ | Enum _ | Union _ as e ->
+                KPrint.bprintf "Error: did not expect %a\n" ppdef e;
                 (* No abbreviations (this runs after inline_type abbrevs).
                  * No Enum / Union / Forward (this runs before data types). *)
                 assert false
+
+            | Forward ->
+                (* Happens when an abstract external type is marked as
+                   CAbstractStruct. TODO this is really unpleasant because
+                   without the annotation, the type wouldn't be generated at all
+                   and would end up "implicitly" external, as in the final case
+                   below. *)
+                gen_poly ~pointer:true ()
+
             | Flat fields ->
                 (* Either a conjunction of equalities, or a disjunction of inequalities. *)
                 let def () =
@@ -572,22 +612,7 @@ let equalities files =
             EQualified (Hashtbl.find Gen.generated_lids (eq_lid, [ t ]))
           with Not_found ->
             (* External type without a definition. Comparison of function types? *)
-            begin match op with
-            | K.PNeq ->
-                (* let __neq__t x y = not (__eq__t x y) *)
-                let def () =
-                  let body = mk_not (with_type TBool (
-                    EApp (with_type eq_typ (self#generate_equality t K.PEq), [
-                      with_type t (EBound 0); with_type t (EBound 1) ])))
-                  in
-                  DFunction (None, [], 0, TBool, instance_lid, [ y; x ], body)
-                in
-                EQualified (Gen.register_def current_file eq_lid [ t ] instance_lid def)
-            | K.PEq ->
-                (* assume val __eq__t: t -> t -> bool *)
-                let def () = DExternal (None, [], instance_lid, eq_typ, [ "x"; "y" ]) in
-                EQualified (Gen.register_def current_file eq_lid [ t ] instance_lid def)
-            end
+            gen_poly ()
 
     (* New feature (somewhat unrelated to polymorphic equality
      * monomorphization): generate top-level specialized equalities in case a
@@ -615,9 +640,9 @@ let equalities files =
                 with_type t (EBound 0); with_type t (EBound 1) ])))))
 
     method! visit_EApp env e es =
-      match e.node with
-      | EPolyComp (op, t) ->
-          EApp (with_type e.typ (self#generate_equality t op), List.map (self#visit_expr env) es)
+      match e.node, es with
+      | EPolyComp (op, t), [ x; y ] ->
+          self#maybe_by_addr (self#generate_equality t op) (self#visit_expr env x) (self#visit_expr env y)
       | _ ->
           EApp (self#visit_expr env e, List.map (self#visit_expr env) es)
 

--- a/test/Abstract.fsti
+++ b/test/Abstract.fsti
@@ -1,0 +1,4 @@
+module Abstract
+
+[@@CAbstractStruct]
+val t : eqtype

--- a/test/AbstractStruct2.fst
+++ b/test/AbstractStruct2.fst
@@ -1,0 +1,30 @@
+module AbstractStruct2
+module HS = FStar.HyperStack
+module B = LowStar.Buffer
+
+open FStar.HyperStack.ST
+
+[@@CAbstractStruct]
+noeq
+type handle = {
+  something: bool;
+  another: AbstractStructAbstract.t AbstractStructParameter.param;
+}
+
+let init (_:unit) =
+  let h = {
+    something = false;
+    another = AbstractStructAbstract.make AbstractStructParameter.({ param_one = true; param_two = false })
+  } in
+  B.malloc HS.root h 1ul
+
+open LowStar.BufferOps
+open AbstractStructParameter
+open AbstractStructAbstract
+
+let main () =
+  let p  = init () in
+  if (read (!*p).another).param_two then
+    1l
+  else
+    0l

--- a/test/AbstractStruct2.fsti
+++ b/test/AbstractStruct2.fsti
@@ -1,0 +1,13 @@
+module AbstractStruct2
+open FStar.HyperStack.ST
+module B = LowStar.Buffer
+
+[@@CAbstractStruct]
+val handle : Type0
+
+val init (_:unit)
+  : ST (B.pointer handle)
+       (requires fun _ -> True)
+       (ensures fun _ handle h1 -> B.live h1 handle)
+
+val main: unit -> St Int32.t

--- a/test/AbstractStructAbstract.fst
+++ b/test/AbstractStructAbstract.fst
@@ -1,0 +1,6 @@
+module AbstractStructAbstract
+
+type t a = (bool & a)
+
+let make #a x = (false, x)
+let read #a t = snd t

--- a/test/AbstractStructAbstract.fsti
+++ b/test/AbstractStructAbstract.fsti
@@ -1,0 +1,6 @@
+module AbstractStructAbstract
+
+val t (a:Type0) : Type0
+
+val make (#a:Type0) (x:a) : t a
+val read (#a:Type0) (x:t a) : a

--- a/test/AbstractStructParameter.fsti
+++ b/test/AbstractStructParameter.fsti
@@ -1,0 +1,7 @@
+module AbstractStructParameter
+
+[@@CAbstractStruct]
+type param = {
+  param_one: bool;
+  param_two: bool
+}

--- a/test/Makefile
+++ b/test/Makefile
@@ -9,7 +9,8 @@ KRML		= $(KRML_BIN) $(KOPTS) $(TEST_OPTS)
 # HigherOrder6?) and helper files that are required for multiple-module tests
 BROKEN		= \
   HigherOrder6.fst ForwardDecl.fst BlitNull.fst \
-  Ctypes1.fst Ctypes2.fst Ctypes3.fst Ctypes4.fst Abstract.fsti
+  Ctypes1.fst Ctypes2.fst Ctypes3.fst Ctypes4.fst \
+  AbstractStructAbstract.fst
 
 # Lowlevel is not really broken, but its test shouldn't be run since it's a
 # special file and doesn't have a main.

--- a/test/Makefile
+++ b/test/Makefile
@@ -5,9 +5,11 @@ TEST_OPTS	= -warn-error @4 -verbose -skip-makefiles
 KRML_BIN	= ../_build/src/Karamel.native
 KRML		= $(KRML_BIN) $(KOPTS) $(TEST_OPTS)
 
+# TODO: disambiguate between broken tests that arguably should work (maybe
+# HigherOrder6?) and helper files that are required for multiple-module tests
 BROKEN		= \
   HigherOrder6.fst ForwardDecl.fst BlitNull.fst \
-  Ctypes1.fst Ctypes2.fst Ctypes3.fst Ctypes4.fst
+  Ctypes1.fst Ctypes2.fst Ctypes3.fst Ctypes4.fst Abstract.fsti
 
 # Lowlevel is not really broken, but its test shouldn't be run since it's a
 # special file and doesn't have a main.
@@ -150,6 +152,7 @@ $(OUTPUT_DIR)/Intro.exe $(OUTPUT_DIR)/MemCpy.exe: EXTRA = -rst-snippets
 $(OUTPUT_DIR)/StaticHeader.exe: EXTRA = -static-header StaticHeaderLib -bundle StaticHeaderAPI=StaticHeaderLib -warn-error @7@8
 $(OUTPUT_DIR)/Unused_B.exe: EXTRA=-bundle Unused_A
 $(OUTPUT_DIR)/PrivateInclude2.exe: EXTRA=-no-prefix PrivateInclude1 -bundle PrivateInclude1 -add-include 'PrivateInclude1.c:"../../foobar.h"'
+$(OUTPUT_DIR)/MonomorphizationCrash.exe: EXTRA=monomorphization_crash.c -add-include 'MonomorphizationCrash.c:"monomorphization_crash.h"' -ccopt -I.
 
 Failure.test: NEGATIVE=true
 

--- a/test/MonomorphizationCrash.fst
+++ b/test/MonomorphizationCrash.fst
@@ -1,0 +1,16 @@
+module MonomorphizationCrash
+open Abstract
+
+type pair = {
+  fst : t;
+  snd : bool
+}
+
+
+assume val mk_t (_:unit) : t
+
+let test (x y:pair) : bool = x = y
+
+let main () =
+  let x = mk_t () in
+  if test ({fst=x; snd=true}) ({fst=x;snd=false}) then 1l else 0l

--- a/test/MonomorphizationCrash.fsti
+++ b/test/MonomorphizationCrash.fsti
@@ -1,0 +1,3 @@
+module MonomorphizationCrash
+
+val main : unit -> Int32.t

--- a/test/monomorphization_crash.c
+++ b/test/monomorphization_crash.c
@@ -1,0 +1,10 @@
+#include "monomorphization_crash.h"
+#include "MonomorphizationCrash.h"
+
+extern Abstract_t mk_t() {
+  return (Abstract_t){ .x = 0 };
+}
+extern bool __eq__Abstract_t(const Abstract_t *x, const Abstract_t *y) {
+  return x->x == y->x;
+}
+

--- a/test/monomorphization_crash.h
+++ b/test/monomorphization_crash.h
@@ -1,0 +1,7 @@
+#pragma once
+
+struct Abstract_t_s {
+  int x;
+};
+
+


### PR DESCRIPTION
This fixes #245

Note: the original test was ill-formed, in that it was declaring a C abstract struct but yet declaring a function that had the ability to *construct* values of the struct type without a pointer.

I had to add some custom hand-written files to make the test work -- I assume this is representative of your scenario.

Please confirm this solves the problem you were encountering, thanks!