### PR TITLE
Properly locate the F* standard library

### DIFF
--- a/src/Driver.ml
+++ b/src/Driver.ml
@@ -229,12 +229,13 @@ let detect_fstar () =
     fatal_error "Did not find fstar.exe in PATH and FSTAR_HOME is not set"
   end;
 
-  if KString.exists !fstar_home "opam"; then begin
+  let fstar_ulib = !fstar_home ^^ "ulib" in
+  if not (Sys.file_exists fstar_ulib && Sys.is_directory fstar_ulib) ; then begin
     if not !Options.silent then
-      KPrint.bprintf "Detected an OPAM setup of F*\n";
+      KPrint.bprintf "F* library not found in ulib; falling back to lib/fstar\n";
     fstar_lib := !fstar_home ^^ "lib" ^^ "fstar"
   end else begin
-    fstar_lib := !fstar_home ^^ "ulib"
+    fstar_lib := fstar_ulib
   end;
 
   if success "which" [| "cygpath" |] then begin


### PR DESCRIPTION
*Scenario 1:* if a user clones the F* repository into a directory whose path contains `opam` (e.g. if the user's login contains `opam`), and compiles it from there, then Karamel will improperly assume that the F* standard library is in `$FSTAR_HOME/lib/fstar` instead of `$FSTAR_HOME/ulib`, claiming that F* was installed by opam.

*Scenario 2:* if a user downloads F* and installs it with `make install`, say into `/usr/local`, then Karamel will improperly assume that the F* standard library is in `$FSTAR_HOME/ulib` instead of `$FSTAR_HOME/lib/fstar`. (F*'s `make install` is indeed used by `opam install fstar`, but not exclusively.)

In both scenarios, such users will not be able to compile HACL* (here in Scenario 1):

<details>
    <summary>Click to expand</summary>

```
Unexpected error
FStar_Errors.Err(_)
Raised at Stdlib__map.Make.find in file "map.ml", line 137, characters 10-25
Called from Sexplib0__Sexp_conv.Exn_converter.find_auto in file "src/sexp_conv.ml", line 156, characters 10-37
(Error 129) File /home/opam/FStar/lib/fstar/FStar.UInt128.fst could not be found
1 error was reported (see above)
Warning 3: run_or_warn: the following command failed:
/home/opam/FStar/bin/fstar.exe --odir aesgcm-c --codegen krml --lax /home/opam/karamel/runtime/WasmSupport.fst /home/opam/FStar/lib/fstar/FStar.UInt128.fst --trace_error --expose_interfaces --include /home/opam/karamel/krmllib --include /home/opam/hacl-star/code/old/../../code/old/lib/krml --include /home/opam/karamel/krmllib/compat --include /home/opam/hacl-star/code/old/../../specs --include /home/opam/hacl-star/code/old/../../specs/old --include . --include /home/opam/karamel/include Crypto.Symmetric.AES.fst Crypto.Symmetric.AES128.fst
Warning 3 is fatal, exiting.
make[4]: *** [Makefile:10: aesgcm-c/out.krml] Error 255
make[4]: Leaving directory '/home/opam/hacl-star/code/old/experimental/aesgcm'
make[3]: *** [Makefile.old:9: experimental/aesgcm-c] Error 2
make[3]: Leaving directory '/home/opam/hacl-star/code/old'
make[2]: *** [Makefile:559: old-extract-c] Error 2
make[2]: Leaving directory '/home/opam/hacl-star'
make[1]: *** [Makefile:120: all-staged] Error 2
make[1]: Leaving directory '/home/opam/hacl-star'
make: *** [Makefile:101: all] Error 2
```

</details>

**This PR** solves both issues at once, by properly checking whether `$FSTAR_HOME/ulib` exists, and if not, falls back to `$FSTAR_HOME/lib/fstar`.
