### PR TITLE
Simplify all trivial let-bindings

### DIFF
--- a/src/Simplify.ml
+++ b/src/Simplify.ml
@@ -28,7 +28,7 @@ let count_and_remove_locals = object (self)
 
   method private remove_trivial_let e =
     match e with
-    | ELet (_, e1, { node = EBound 0; _ }) when Helpers.is_readonly_c_expression e1 ->
+    | ELet (_, e1, { node = EBound 0; _ }) ->
         e1.node
     | _ ->
         e


### PR DESCRIPTION
In particular, it handle some cases where `let x = ... in x` appears at the end of a function after inlining.