### PR TITLE
Automatically ignore unused local variables

### DIFF
--- a/src/AstToCStar.ml
+++ b/src/AstToCStar.ml
@@ -274,6 +274,12 @@ let rec mk_expr env in_stmt e =
   | EAddrOf e ->
       CStar.AddrOf (mk_expr env e)
 
+  | EIgnore e ->
+      (* An ignore node ended up in expression position. Rather than have a
+         sketchy macro, we just drop the ignore here and make it a "best-effort"
+         thing. *)
+      mk_expr env e
+
   | _ ->
       Warn.maybe_fatal_error (KPrint.bsprintf "%a" Loc.ploc env.location, NotLowStar e);
       CStar.Any

--- a/src/Helpers.ml
+++ b/src/Helpers.ml
@@ -416,8 +416,11 @@ let rec nest_in_return_pos i typ f e =
         t, nest_in_return_pos i typ f e
       ) branches in
       { node = ESwitch (e, branches); typ }
-  | EMatch _ ->
-      failwith "Matches should've been desugared"
+  | EMatch (e, branches) ->
+      let branches = List.map (fun (bs, p, e) ->
+        bs, p, nest_in_return_pos i typ f e
+      ) branches in
+      { node = EMatch (e, branches); typ }
   | ESequence es ->
       let l = List.length es in
       { node = ESequence (List.mapi (fun j e ->

--- a/src/Simplify.ml
+++ b/src/Simplify.ml
@@ -49,8 +49,9 @@ let count_and_remove_locals = object (self)
          *   int unused = f();
          * or:
          *   (void)f(); ? *)
-        (* ELet ({ node = { b.node with meta = Some MetaSequence }; typ = TUnit}, push_ignore e1, e2) *)
-        self#remove_trivial_let (ELet (b, e1, e2))
+        self#remove_trivial_let (
+          ELet ({ node = { b.node with meta = Some MetaSequence }; typ = TUnit}, push_ignore e1, e2))
+        (* self#remove_trivial_let (ELet (b, e1, e2)) *)
     else
       self#remove_trivial_let (ELet (b, e1, e2))
 


### PR DESCRIPTION
krml performs a def-use analysis to detect unused variables; if they are trivially readonly, these are just skipped from the code-gen; if they are not obviously readonly (e.g. function call), then the current behavior is to leave an unused variable in the generated code to preserve potential side-effects

an alternate strategy is to cast to `(void)` the definition without introducing a generated variable, so as to silence C compiler warnings, which this PR does