### PR TITLE
Improve code-generation for arrays of vectors.

### DIFF
--- a/src/Helpers.ml
+++ b/src/Helpers.ml
@@ -248,6 +248,16 @@ let is_readonly_builtin_lid lid =
     KString.starts_with lid lid'
   ) pure_builtin_lids
 
+class ['self] closed_term_visitor = object (_: 'self)
+  inherit [_] reduce
+  method private zero = true
+  method private plus = (&&)
+  method! visit_EBound _ _ = false
+  method! visit_EOpen _ _ _ = false
+end
+
+let is_closed_term = (new closed_term_visitor)#visit_expr_w ()
+
 class ['self] readonly_visitor = object (self: 'self)
   inherit [_] reduce
   method private zero = true

--- a/src/Karamel.ml
+++ b/src/Karamel.ml
@@ -625,7 +625,12 @@ Supported options:|}
   (* Note: generates let-bindings, so needs to be before simplify2 *)
   let files = Simplify.remove_unused files in
   let files = if !Options.tail_calls then Simplify.tail_calls files else files in
-  let files = Simplify.simplify2 files in
+
+  (* This allows drop'ing the module that contains just ifdefs. *)
+  let ifdefs = AstToCStar.mk_ifdefs_set files in
+  let macros = AstToCStar.mk_macros_set files in
+
+  let files = Simplify.simplify2 ifdefs files in
   let files = if Options.(!merge_variables <> No) then SimplifyMerge.simplify files else files in
   if !arg_print_structs then
     print PrintAst.print_files files;
@@ -639,10 +644,6 @@ Supported options:|}
     else
       files
   in
-
-  (* This allows drop'ing the module that contains just ifdefs. *)
-  let ifdefs = AstToCStar.mk_ifdefs_set files in
-  let macros = AstToCStar.mk_macros_set files in
 
   (* 6. Drop both files and selected declarations within some files, as a [-drop
    * Foo -bundle Bar=Foo] command-line requires us to go inside file [Bar] to

--- a/src/Simplify.ml
+++ b/src/Simplify.ml
@@ -1355,7 +1355,9 @@ let tail_calls =
  * This function assumes [hoist] has been run so that every single [EBufCreate]
  * appears as a [let x = bufcreate...], always in statement position.
  *)
-let rec hoist_bufcreate (e: expr) =
+let rec hoist_bufcreate ifdefs (e: expr) =
+  let hoist_bufcreate = hoist_bufcreate ifdefs in
+  let under_pushframe = under_pushframe ifdefs in
   let mk node = { node; typ = e.typ } in
   match e.node with
   | EMatch _ ->
@@ -1390,26 +1392,29 @@ let rec hoist_bufcreate (e: expr) =
        * proper instructions now. *)
       begin match strengthen_array b.typ e1 with
       | TArray (t, size) as tarray ->
+          (* b is the binder that is about to be moved up *)
           let b, e2 = open_binder b e2 in
-          (* Any assignments into this one will be desugared as a
+          (* Any assignments into b will be desugared as a
            * copy-assignment, thanks to the strengthened type. *)
           let b = { b with typ = tarray } in
           let bs, e2 = hoist_bufcreate e2 in
           (* WASM/C discrepancy; in C, the array type makes sure we allocate
            * stack space. In Wasm, we rely on the expression to actually
            * generate run-time code. *)
-          let init = with_type (TBuf (t, false)) (
-            EBufCreate (Common.Stack, any, with_type uint32 (EConstant size)))
+          let init e = with_type (TBuf (t, false)) (
+            EBufCreate (Common.Stack, e, with_type uint32 (EConstant size)))
           in
-          (mark_mut b, init) :: bs,
           begin match e1.node with
           | EAny ->
               failwith "not allowing that per WASM restrictions"
+          | EBufCreate (_, e, _) when Helpers.is_closed_term e ->
+              (b, init e) :: bs, e2
           | EBufCreate (_, { node = EAny; _ }, _) ->
               (* We're visiting this node again. *)
-              e2
+              (mark_mut b, init any) :: bs, e2
           | _ ->
               (* Need actual copy-assigment. *)
+              (mark_mut b, init any) :: bs,
               mk (ELet (sequence_binding (),
                 with_type TUnit (mk_copy_assignment (t, size) (EOpen (b.node.name, b.node.atom)) e1),
                 lift 1 e2
@@ -1424,13 +1429,34 @@ let rec hoist_bufcreate (e: expr) =
   | _ ->
       [], e
 
-and under_pushframe (e: expr) =
+(* TODO: the control-flow is super convoluted here. Also, why the difference in
+   treatment between while loops and for loops above? Is this some ancient
+   Dafny-related stuff? In any case, I believe the two mutually-recursive
+   functions could be greatly clarified if they operated at the level of lets
+   instead of alternating between the sequence of statements (all lets) and the
+   bodies of the lets themselves. *)
+and under_pushframe ifdefs (e: expr) =
+  let hoist_bufcreate = hoist_bufcreate ifdefs in
+  let under_pushframe = under_pushframe ifdefs in
   let mk node = { node; typ = e.typ } in
   match e.node with
+  | ELet (b, { node = EIfThenElse ({ node = EQualified lid; _ } as e1, e2, e3); typ }, ek)
+    when Idents.LidSet.mem lid ifdefs ->
+      (* Do not hoist, since this if will turn into an ifdef which does NOT
+         shorten the scope...! *)
+      let e2 = under_pushframe e2 in  
+      let e3 = under_pushframe e3 in  
+      let ek = under_pushframe ek in
+      mk (ELet (b, { node = EIfThenElse (e1, e2, e3); typ }, ek))
   | ELet (b, e1, e2) ->
       let b1, e1 = hoist_bufcreate e1 in
       let e2 = under_pushframe e2 in
       nest b1 e.typ (mk (ELet (b, e1, e2)))
+  | EIfThenElse ({ node = EQualified lid; _ } as e1, e2, e3)
+    when Idents.LidSet.mem lid ifdefs ->
+      let e2 = under_pushframe e2 in  
+      let e3 = under_pushframe e3 in  
+      mk (EIfThenElse (e1, e2, e3))
   | _ ->
       let b, e' = hoist_bufcreate e in
       nest b e.typ e'
@@ -1441,33 +1467,42 @@ and under_pushframe (e: expr) =
  * - or, something happens (e.g. allocation), and this means that the function
  *   WILL be inlined, and that its caller will take care of hoisting things up
  *   in the second round.
+ *
+ * JP, 20220810: the second case above seems EXTREMELY outdated, since now all
+ * StackInline functions are also marked as inline_for_extraction.
+ *
  * Note: we could do this in a simpler manner with a visitor whose env is a
  * [ref * (list (binder * expr))] but that would degrade the quality of the
  * code. This recursive routine is smarter and preserves the sequence of
  * let-bindings starting from the beginning of the scope. *)
-let rec skip (e: expr) =
+let rec find_pushframe ifdefs (e: expr) =
   let mk node = { node; typ = e.typ } in
   match e.node with
   | ELet (b, ({ node = EPushFrame; _ } as e1), e2) ->
-      mk (ELet (b, e1, under_pushframe e2))
+      mk (ELet (b, e1, under_pushframe ifdefs e2))
   | ELet (b, e1, e2) ->
-      mk (ELet (b, skip e1, skip e2))
+      (* No need to descend into `e1` since we won't find let bindings there. *)
+      mk (ELet (b, e1, find_pushframe ifdefs e2))
   (* Descend into conditionals that are in return position. *)
   | EIfThenElse (e1, e2, e3) ->
-      mk (EIfThenElse (e1, skip e2, skip e3))
+      mk (EIfThenElse (e1, find_pushframe ifdefs e2, find_pushframe ifdefs e3))
   | ESwitch (e, branches) ->
-      mk (ESwitch (e, List.map (fun (t, e) -> t, skip e) branches))
+      mk (ESwitch (e, List.map (fun (t, e) -> t, find_pushframe ifdefs e) branches))
   | _ ->
       e
 
-(* TODO: figure out if we want to ignore the other cases for performance
- * reasons. *)
+(* This phase operates after `hoist` and `let_if_to_assign`, meaning we can rely
+  on a few invariants:
+  - let-bindings do not nest right
+  - buffer allocations are always immediately underneath a let-bindings
+  - ifs are in statement position
+  - there are no sequences, but unit let-bindings. *)
 let hoist_bufcreate = object
   inherit [_] map
 
-  method visit_DFunction () cc flags n ret name binders expr =
+  method visit_DFunction ifdefs cc flags n ret name binders expr =
     try
-      DFunction (cc, flags, n, ret, name, binders, skip expr)
+      DFunction (cc, flags, n, ret, name, binders, find_pushframe ifdefs expr)
     with Fatal s ->
       KPrint.bprintf "Fatal error in %a:\n%s\n" plid name s;
       exit 151
@@ -1705,7 +1740,7 @@ let simplify1 (files: file list): file list =
  * allocations and writes are hoisted; where if-then-else is always in statement
  * position; where sequences are not nested. These series of transformations
  * re-establish this invariant. *)
-let simplify2 (files: file list): file list =
+let simplify2 ifdefs (files: file list): file list =
   let files = sequence_to_let#visit_files () files in
   (* Quality of hoisting is WIDELY improved if we remove un-necessary
    * let-bindings. *)
@@ -1713,9 +1748,9 @@ let simplify2 (files: file list): file list =
   let files = if !Options.wasm then files else fixup_while_tests#visit_files () files in
   let files = hoist#visit_files [] files in
   let files = if !Options.c89_scope then SimplifyC89.hoist_lets#visit_files (ref []) files else files in
-  let files = if !Options.wasm then files else hoist_bufcreate#visit_files () files in
   let files = if !Options.wasm then files else fixup_hoist#visit_files () files in
   let files = if !Options.wasm then files else let_if_to_assign#visit_files () files in
+  let files = if !Options.wasm then files else hoist_bufcreate#visit_files ifdefs files in
   let files = misc_cosmetic#visit_files () files in
   let files = functional_updates#visit_files false files in
   let files = functional_updates#visit_files true files in


### PR DESCRIPTION
- krml is now aware that HACL's vec128_zero, vec256_zero and so on are
  zeroes and as such that a for-loop is not needed for compiling
  allocations, and a zero-initializer suffices
- an if-statement that is about to compiled as an ifdef can be safely
  ignored for the sake of the buffer-hoisting phase
- improved buffer hoisting: if the initial value is a closed term, do
  not bother with a copy assignment and lift the array declaration
  wholesale