### PR TITLE
Make WASM code-gen more resilient

### DIFF
--- a/src/AstToCStar.ml
+++ b/src/AstToCStar.ml
@@ -185,6 +185,7 @@ type return_pos =
   | Not
   | May
   | Must
+[@@deriving show]
 
 type binder_pos = Function | Local
 

--- a/src/Inlining.ml
+++ b/src/Inlining.ml
@@ -286,7 +286,7 @@ let cross_call_analysis files =
     val mutable name = [],""
     method! visit_EQualified ((_, t) as env) name' =
       if !Options.wasm && cross_call name name' && Hashtbl.mem wasm_mutable name' then begin
-        if Options.debug "wasm" then
+        if Options.debug "wasm" && not (Hashtbl.mem getters name') then
           KPrint.bprintf "%a accesses %a, a mutable global, across modules: getter \
             must be generated\n" plid name plid name';
         Hashtbl.add getters name' ();


### PR DESCRIPTION
Essentially, these two commits turn non-recoverable code-generation errors into run-time failures on the faulty subexpression. This is particularly useful for compiling some EverCrypt modules: sometimes, a branch will never be taken at run-time in WASM, but still e.g. contains code intended for 256-bit platforms (which WASM isn't).

Rather than raising an exception and failing to compile the whole function, we need turn the faulty branch into a run-time failure, which, by virtue of being never taken at run-time, still makes the whole function work in WASM.