### PR TITLE
Generate suitable alignment directives for types that require alignment

### DIFF
--- a/include/krml/internal/target.h
+++ b/include/krml/internal/target.h
@@ -46,6 +46,38 @@
 #  define KRML_HOST_FREE free
 #endif
 
+#ifndef KRML_PRE_ALIGN
+#  ifdef _MSC_VER
+#    define KRML_PRE_ALIGN(X) __declspec(align(X))
+#  else
+#    define KRML_PRE_ALIGN(X)
+#  endif
+#endif
+
+#ifndef KRML_POST_ALIGN
+#  ifdef _MSC_VER
+#    define KRML_POST_ALIGN(X)
+#  else
+#    define KRML_POST_ALIGN(X) __attribute__((aligned(X)))
+#  endif
+#endif
+
+#ifndef KRML_ALIGNED_MALLOC
+#  ifdef _MSC_VER
+#    define KRML_ALIGNED_MALLOC(X, Y) _aligned_malloc(X, Y)
+#  else
+#    define KRML_ALIGNED_MALLOC(X, Y) aligned_alloc(X, Y)
+#  endif
+#endif
+
+#ifndef KRML_ALIGNED_FREE
+#  ifdef _MSC_VER
+#    define KRML_ALIGNED_FREE(X) _aligned_free(X)
+#  else
+#    define KRML_ALIGNED_FREE(X) free(X)
+#  endif
+#endif
+
 #ifndef KRML_HOST_TIME
 
 #  include <time.h>

--- a/include/krml/internal/target.h
+++ b/include/krml/internal/target.h
@@ -64,7 +64,7 @@
 
 #ifndef KRML_ALIGNED_MALLOC
 #  ifdef _MSC_VER
-#    define KRML_ALIGNED_MALLOC(X, Y) _aligned_malloc(X, Y)
+#    define KRML_ALIGNED_MALLOC(X, Y) _aligned_malloc(Y, X)
 #  else
 #    define KRML_ALIGNED_MALLOC(X, Y) aligned_alloc(X, Y)
 #  endif

--- a/src/AstToCStar.ml
+++ b/src/AstToCStar.ml
@@ -467,7 +467,7 @@ and mk_stmts env e ret_type =
         env, maybe_return (e :: acc)
 
     | EBufFree e ->
-        let e = CStar.BufFree (mk_expr env false e) in
+        let e = CStar.BufFree (mk_type env (assert_tbuf e.typ), mk_expr env false e) in
         env, maybe_return (e :: acc)
 
     | EMatch _ ->

--- a/src/C11.ml
+++ b/src/C11.ml
@@ -29,7 +29,10 @@ and qualifier =
   | Restrict
 
 and declarator_and_init =
-  declarator * init option
+  declarator * alignment option * init option
+
+and alignment =
+  expr
 
 and declarator_and_inits =
   declarator_and_init list

--- a/src/CStar.ml
+++ b/src/CStar.ml
@@ -42,7 +42,7 @@ and stmt =
     (** First expression has to be a [Bound] or [Open]. *)
   | BufBlit of typ * expr * expr * expr * expr * expr
   | BufFill of typ * expr * expr * expr
-  | BufFree of expr
+  | BufFree of typ * expr
   | Block of block
   | Comment of string
 

--- a/src/CStarToC11.ml
+++ b/src/CStarToC11.ml
@@ -680,10 +680,12 @@ and is_aligned_type = function
 and mk_alignment m t: C11.expr option =
   if is_aligned_type t then
     match t with
-    | Qualified (["Lib"; "IntVector"; "Intrinsics"], "vec128")
-    | Qualified (["Lib"; "IntVector"; "Intrinsics"], "vec256")
-    | Qualified (["Lib"; "IntVector"; "Intrinsics"], "vec512") ->
+    | Qualified (["Lib"; "IntVector"; "Intrinsics"], "vec128") ->
         Some (Constant (CInt, "16"))
+    | Qualified (["Lib"; "IntVector"; "Intrinsics"], "vec256") ->
+        Some (Constant (CInt, "32"))
+    | Qualified (["Lib"; "IntVector"; "Intrinsics"], "vec512") ->
+        Some (Constant (CInt, "64"))
     | _ ->
         Some (Sizeof (Type (mk_type m t)))
   else

--- a/src/CStarToC11.ml
+++ b/src/CStarToC11.ml
@@ -680,12 +680,10 @@ and is_aligned_type = function
 and mk_alignment m t: C11.expr option =
   if is_aligned_type t then
     match t with
-    | Qualified (["Lib"; "IntVector"; "Intrinsics"], "vec128") ->
-        Some (Constant (CInt, "16"))
-    | Qualified (["Lib"; "IntVector"; "Intrinsics"], "vec256") ->
-        Some (Constant (CInt, "32"))
+    | Qualified (["Lib"; "IntVector"; "Intrinsics"], "vec128")
+    | Qualified (["Lib"; "IntVector"; "Intrinsics"], "vec256")
     | Qualified (["Lib"; "IntVector"; "Intrinsics"], "vec512") ->
-        Some (Constant (CInt, "64"))
+        Some (Constant (CInt, "16"))
     | _ ->
         Some (Sizeof (Type (mk_type m t)))
   else

--- a/src/Helpers.ml
+++ b/src/Helpers.ml
@@ -169,6 +169,10 @@ let flatten_arrow =
 let fold_arrow ts t_ret =
   List.fold_right (fun t arr -> TArrow (t, arr)) ts t_ret
 
+(* TODO: figure this out through an attribute in the source code
+   rather than a hardcoded list in krml *)
+let is_aligned_type = function ["Lib"; "IntVector"; "Intrinsics"], ("vec128"|"vec256"|"vec512") -> true | _ -> false
+
 let is_array = function TArray _ -> true | _ -> false
 
 let is_union = function TAnonymous (Union _) -> true | _ -> false

--- a/src/PrintC.ml
+++ b/src/PrintC.ml
@@ -299,8 +299,16 @@ and p_designator = function
   | Bracket i ->
       lbracket ^^ int i ^^ rbracket
 
-and p_decl_and_init (decl, init) =
-  group (p_type_declarator decl ^^ match init with
+and p_decl_and_init (decl, alignment, init) =
+  let pre, post = match alignment with
+    | Some t ->
+        p_expr (Call (Name "KRML_PRE_ALIGN", [ t ])) ^^ break1,
+        break1 ^^ p_expr (Call (Name "KRML_POST_ALIGN", [ t ]))
+    | None ->
+        empty,
+        empty
+  in
+  group (pre ^^ p_type_declarator decl ^^ post ^^ match init with
     | Some init ->
         space ^^ equals ^^ jump (p_init init)
     | None ->

--- a/src/PrintC.ml
+++ b/src/PrintC.ml
@@ -300,15 +300,13 @@ and p_designator = function
       lbracket ^^ int i ^^ rbracket
 
 and p_decl_and_init (decl, alignment, init) =
-  let pre, post = match alignment with
+  let post = match alignment with
     | Some t ->
-        p_expr (Call (Name "KRML_PRE_ALIGN", [ t ])) ^^ break1,
         break1 ^^ p_expr (Call (Name "KRML_POST_ALIGN", [ t ]))
     | None ->
-        empty,
         empty
   in
-  group (pre ^^ p_type_declarator decl ^^ post ^^ match init with
+  group (p_type_declarator decl ^^ post ^^ match init with
     | Some init ->
         space ^^ equals ^^ jump (p_init init)
     | None ->
@@ -317,7 +315,17 @@ and p_decl_and_init (decl, alignment, init) =
 and p_declaration (qs, spec, inline, stor, decl_and_inits) =
   let inline = if inline then string "inline" ^^ space else empty in
   let stor = match stor with Some stor -> p_storage_spec stor ^^ space | None -> empty in
-  stor ^^ inline ^^ p_qualifiers_break qs ^^ group (p_type_spec spec) ^/^
+  let _, alignment, _ = List.hd decl_and_inits in
+  if not (List.for_all (fun (_, a, _) -> a = alignment) decl_and_inits) then
+    Warn.fatal_error "In a declarator group, not all declarations have the same \
+      alignment, which is not supported for MSVC. Bailing.";
+  let pre = match alignment with
+    | Some t ->
+        p_expr (Call (Name "KRML_PRE_ALIGN", [ t ])) ^^ break1
+    | None ->
+        empty
+  in
+  pre ^^ stor ^^ inline ^^ p_qualifiers_break qs ^^ group (p_type_spec spec) ^/^
   separate_map (comma ^^ break 1) p_decl_and_init decl_and_inits
 
 


### PR DESCRIPTION
Right now, this covers the intvector types from HACL*. In the long run, it would of course be nice to define this on the original F* type via an attribute.

No support yet for libintvector.vec512 -- to be added in due time.