### PR TITLE
Print toplevel comments with Doxygen syntax

### DIFF
--- a/src/PrintC.ml
+++ b/src/PrintC.ml
@@ -405,7 +405,7 @@ and p_stmt (s: stmt) =
 and p_stmts stmts = separate_map hardline p_stmt stmts
 
 let p_comments cs =
-  separate_map hardline (fun c -> string ("/*\n" ^ c ^ "\n*/")) cs ^^
+  separate_map hardline (fun c -> string ("/**\n" ^ c ^ "\n*/")) cs ^^
   if List.length cs > 0 then hardline else empty
 
 let p_microsoft_comments cs =


### PR DESCRIPTION
In Microsoft mode, comments are printed with a special syntax so that they can be interpreted by documentation tools. This is actually a good idea, and we should do the same by default, on the basis that if a comment is not proper Doxygen syntax, nothing bad happens.

CCing @duesee and @franziskuskiefer who have requested this