### PR TITLE
Add C._zero_for_deref to list of builtins

### DIFF
--- a/src/Builtin.ml
+++ b/src/Builtin.ml
@@ -410,7 +410,12 @@ let prepare files =
         name, snd f @ extra
       with Not_found ->
         f
-  ) files @ if List.mem_assoc "C" files then [] else [c_deref]
+  ) files @
+  (* This is unfortunately needed because of PR #278, and especially the corresponding
+     F* PR: References to module C can now occur even when the module is not in the scope.
+     If so, we add the definition that is needed as a builtin, since it will be rewritten
+     during C code generation *)
+  if List.mem_assoc "C" files then [] else [c_deref]
 
 let make_libraries files =
   List.map (fun f ->

--- a/src/Builtin.ml
+++ b/src/Builtin.ml
@@ -394,7 +394,7 @@ let is_model name =
 (* We have several different treatments. *)
 let prepare files =
   (* prims is a special-case, as it is not extracted by F* (FIXME) *)
-  prims :: steel_reference :: c_deref :: List.map (fun f ->
+  prims :: steel_reference :: List.map (fun f ->
     let name = fst f in
     (* machine integers, some modules from the C namespace just become abstract in Low*. *)
     let f = if is_model name then make_abstract f else f in
@@ -410,7 +410,7 @@ let prepare files =
         name, snd f @ extra
       with Not_found ->
         f
-  ) files
+  ) files @ if List.mem_assoc "C" files then [] else [c_deref]
 
 let make_libraries files =
   List.map (fun f ->

--- a/src/Builtin.ml
+++ b/src/Builtin.ml
@@ -309,6 +309,11 @@ let lib_memzero0: file =
     mk_val [ "Lib"; "Memzero0" ] "memzero" (TArrow (TAny, TArrow (TInt UInt32, TUnit)))
   ]
 
+let c_deref: file =
+  "C", [
+    mk_val ["C"] "_zero_for_deref" (TInt UInt32)
+  ]
+
 (* These modules are entirely written by hand in abstract syntax. *)
 let hand_written = [
   buffer;
@@ -389,7 +394,7 @@ let is_model name =
 (* We have several different treatments. *)
 let prepare files =
   (* prims is a special-case, as it is not extracted by F* (FIXME) *)
-  prims :: steel_reference :: List.map (fun f ->
+  prims :: steel_reference :: c_deref :: List.map (fun f ->
     let name = fst f in
     (* machine integers, some modules from the C namespace just become abstract in Low*. *)
     let f = if is_model name then make_abstract f else f in

--- a/test/Deref2.fst
+++ b/test/Deref2.fst
@@ -1,0 +1,10 @@
+module Deref2
+
+open Steel.Effect
+open Steel.Reference
+
+let test1 () : SteelT UInt32.t emp (fun _ -> emp)
+= let r = malloc 0ul in
+  let x = read r in
+  free r;
+  x

--- a/test/Deref2.fst
+++ b/test/Deref2.fst
@@ -1,5 +1,6 @@
 module Deref2
 
+open Steel.Effect.Atomic
 open Steel.Effect
 open Steel.Reference
 
@@ -9,4 +10,4 @@ let test1 () : SteelT UInt32.t emp (fun _ -> emp)
   free r;
   x
 
-let main : Int32.t = 0l
+let main () : SteelT Int32.t emp (fun _ -> emp) = return 0l

--- a/test/Deref2.fst
+++ b/test/Deref2.fst
@@ -8,3 +8,5 @@ let test1 () : SteelT UInt32.t emp (fun _ -> emp)
   let x = read r in
   free r;
   x
+
+let main : Int32.t = 0l


### PR DESCRIPTION
This PR builds on top of #278, which added specific, more idiomatic extraction for reads on arrays.
The previous PR added a special value, C._zero_for_deref, which serves as a marker for more idiomatic extraction.
This PR marks this value as a builtin, to avoid adding an undefined reference to C._zero_for_deref when C is not in scope.

cc @tahina-pro 