### PR TITLE
Simplify Steel extraction

### DIFF
--- a/krmllib/Makefile
+++ b/krmllib/Makefile
@@ -99,19 +99,6 @@ $(MINI_DIR):
 $(GENERIC_DIR):
 	mkdir -p $@
 
-FILTERED_STEEL_FILES = \
-  $(EXTRACT_DIR)/FStar_MSTTotal.krml \
-  $(EXTRACT_DIR)/FStar_NMSTTotal.krml \
-  $(EXTRACT_DIR)/FStar_NMST.krml \
-  $(EXTRACT_DIR)/FStar_MST.krml \
-  $(EXTRACT_DIR)/Steel_Effect.krml \
-  $(EXTRACT_DIR)/Steel_Effect_Atomic.krml \
-  $(EXTRACT_DIR)/Steel_ST_Effect_Atomic.krml \
-  $(EXTRACT_DIR)/Steel_HigherReference.krml \
-  $(EXTRACT_DIR)/Steel_Reference.krml \
-  $(EXTRACT_DIR)/Steel_Semantics_Hoare_MST.krml
-ALL_KRML_FILES:= $(filter-out $(FILTERED_STEEL_FILES), $(ALL_KRML_FILES))
-
 # Everything in the universe
 $(GENERIC_DIR)/Makefile.include: $(ALL_KRML_FILES) | $(GENERIC_DIR) $(wildcard c/*.c) $(wildcard c/*.h) ../_build/src/Karamel.native
 	../krml $(KRML_ARGS) -tmpdir $(GENERIC_DIR) \

--- a/src/Builtin.ml
+++ b/src/Builtin.ml
@@ -322,6 +322,7 @@ let hand_written = [
   lowstar_endianness;
   monotonic_hh;
   monotonic_hs;
+  steel_reference;
   steel_sizet_intros;
   hs;
   dyn;
@@ -395,7 +396,7 @@ let is_model name =
 (* We have several different treatments. *)
 let prepare files =
   (* prims is a special-case, as it is not extracted by F* (FIXME) *)
-  prims :: steel_reference :: List.map (fun f ->
+  prims :: List.map (fun f ->
     let name = fst f in
     (* machine integers, some modules from the C namespace just become abstract in Low*. *)
     let f = if is_model name then make_abstract f else f in
@@ -411,7 +412,7 @@ let prepare files =
         name, snd f @ extra
       with Not_found ->
         f
-  ) (List.remove_assoc "Steel_Reference" files) @
+  ) files @
   (* This is unfortunately needed because of PR #278, and especially the corresponding
      F* PR: References to module C can now occur even when the module is not in the scope.
      If so, we add the definition that is needed as a builtin, since it will be rewritten

--- a/src/Builtin.ml
+++ b/src/Builtin.ml
@@ -411,7 +411,7 @@ let prepare files =
         name, snd f @ extra
       with Not_found ->
         f
-  ) files @
+  ) (List.remove_assoc "Steel_Reference" files) @
   (* This is unfortunately needed because of PR #278, and especially the corresponding
      F* PR: References to module C can now occur even when the module is not in the scope.
      If so, we add the definition that is needed as a builtin, since it will be rewritten

--- a/test/Makefile
+++ b/test/Makefile
@@ -72,10 +72,9 @@ everything: all wasm
 
 ifndef MAKE_RESTARTS
 ifndef NODEPEND
-# AF: The Steel files should not be extracted by KaRaMeL, they are filtered out
 .depend: .FORCE
 	$(FSTAR) --dep full $(subst .wasm-test,.fst,$(WASM_FILES)) $(subst .test,.fst,$(FILES)) \
-	  $(BROKEN) ../runtime/WasmSupport.fst --extract 'krml:*,-Prims,-FStar.MSTTotal,-FStar.NMSTTotal,-FStar.MST,-FStar.NMST,-Steel.Effect,-Steel.Effect.Atomic,-Steel.HigherReference,-Steel.Reference,-Steel.Semantics.Hoare.MST,-Steel.ST.Effect.Atomic,-Steel.ST.Coercions' > $@
+	  $(BROKEN) ../runtime/WasmSupport.fst --extract 'krml:*,-Prims' > $@
 
 .PHONY: .FORCE
 .FORCE:

--- a/test/Makefile
+++ b/test/Makefile
@@ -84,20 +84,6 @@ endif
 
 include .depend
 
-# AF: The Steel files should not be extracted by KaRaMeL, they are filtered out
-FILTERED_STEEL_FILES = \
-  $(OUTPUT_DIR)/FStar_MSTTotal.krml \
-  $(OUTPUT_DIR)/FStar_NMSTTotal.krml \
-  $(OUTPUT_DIR)/FStar_NMST.krml \
-  $(OUTPUT_DIR)/FStar_MST.krml \
-  $(OUTPUT_DIR)/Steel_Effect.krml \
-  $(OUTPUT_DIR)/Steel_Effect_Atomic.krml \
-  $(OUTPUT_DIR)/Steel_ST_Effect_Atomic.krml \
-  $(OUTPUT_DIR)/Steel_HigherReference.krml \
-  $(OUTPUT_DIR)/Steel_Reference.krml \
-  $(OUTPUT_DIR)/Steel_Semantics_Hoare_MST.krml
-FILTERED_KRML_FILES = $(filter-out $(FILTERED_STEEL_FILES), $(ALL_KRML_FILES))
-
 $(HINTS_DIR):
 	mkdir -p $@
 


### PR DESCRIPTION
Following the fix to extraction in FStarLang/FStar#2754, this PR simplifies the build of Steel-related files.
It also tweaks the handling of Steel.Reference. The previous version was only correct because Steel_Reference.krml was always ignored, but led to duplicated libraries when adding it to Builtins.