### PR TITLE
Add support for -version flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ tags
 book/_build
 fstar-mode.el
 .#*
+src/Version.ml

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ src/AutoConfig.ml:
 
 .PHONY: src/Version.ml
 src/Version.ml:
-	git rev-parse HEAD > $@
+	@echo "let version = \"$(shell (git rev-parse HEAD))\"" > $@ \
 
 clean:
 	rm -rf krml _build Karamel.$(FLAVOR)

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ all: minimal pre krmllib
 	OCAML_ERROR_STYLE="short" \
 	OCAMLPATH="$(OCAMLPATH)$(OCAMLPATH_SEP)$(FSTAR_HOME)/bin" $(OCAMLBUILD) $(EXTRA_TARGETS)
 
-minimal: src/AutoConfig.ml
+minimal: src/AutoConfig.ml src/Version.ml
 	@# Workaround Windows bug in OCamlbuild
 	$(shell [ -f Karamel.$(FLAVOR) ] && rm Karamel.$(FLAVOR))
 	OCAML_ERROR_STYLE="short" $(OCAMLBUILD) $(TARGETS)
@@ -41,6 +41,10 @@ src/AutoConfig.ml:
 	  echo "let misc_dir = \"\";;" >> $@; \
 	fi
 
+.PHONY: src/Version.ml
+src/Version.ml:
+	git rev-parse HEAD > $@
+
 clean:
 	rm -rf krml _build Karamel.$(FLAVOR)
 	$(MAKE) -C test clean
@@ -55,6 +59,7 @@ pre:
 	  { echo "Didn't find fstar.exe in the path or in FSTAR_HOME (which is: $(FSTAR_HOME))"; exit 1; }
 	@ocamlfind query fstarlib >/dev/null 2>&1 || [ -f $(FSTAR_HOME)/bin/fstarlib/fstarlib.cmxa ] || \
 	  { echo "Didn't find fstarlib via ocamlfind or in FSTAR_HOME (which is: $(FSTAR_HOME)); run $(MAKE) -C $(FSTAR_HOME)/ulib/ml"; exit 1; }
+
 
 install: all
 	@if [ x"$(PREFIX)" = x ]; then echo "please define PREFIX"; exit 1; fi

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ src/AutoConfig.ml:
 
 .PHONY: src/Version.ml
 src/Version.ml:
-	@echo "let version = \"$(shell (git rev-parse HEAD))\"" > $@ \
+	@echo "let version = \"$(shell git rev-parse HEAD)\"" > $@ \
 
 clean:
 	rm -rf krml _build Karamel.$(FLAVOR)

--- a/src/Karamel.ml
+++ b/src/Karamel.ml
@@ -39,6 +39,7 @@ module Time = struct
 end
 
 let _ =
+  let arg_version = ref false in
   let arg_print_ast = ref false in
   let arg_print_json = ref false in
   let arg_print_simplify = ref false in
@@ -176,7 +177,7 @@ Supported options:|}
     match String.split_on_char ':' s with
     | [ h; i ] ->
         begin match Filename.chop_suffix_opt ~suffix:".c" h with
-        | Some h -> 
+        | Some h ->
             COnly h, i
         | None ->
             HeaderOnly h, i
@@ -338,6 +339,9 @@ Supported options:|}
       comma-separated list of values; currently supported: \
       inline,bundle,reachability,c-calls,wasm-calls,wasm-memory,wasm,force-c,cflat";
     "", Arg.Unit (fun _ -> ()), " ";
+
+      (* General utilities *)
+    "-version", Arg.Set arg_version, " Display version number";
   ] in
   let spec = Arg.align spec in
   let rec anon_fun f =
@@ -379,6 +383,11 @@ Supported options:|}
     KPrint.bprintf "Complete invocation was: %s\n"
       (String.concat "␣" (Array.to_list Sys.argv));
     exit 1
+  end;
+
+  if !arg_version then begin
+    Printf.printf "KaRaMeL version: %s\n" Version.version;
+    exit 0
   end;
 
   if not !found_file ||


### PR DESCRIPTION
This PR extends krml with a new option, called -version, which displays the current version of KaRaMeL (as its current commit hash).
When krml is invoked with the -version, krml exits with return code 0 immediately after printing the version number.