### PR TITLE
Fix a subtle interaction between CAbstractStruct and -library

### DIFF
--- a/src/Builtin.ml
+++ b/src/Builtin.ml
@@ -346,6 +346,9 @@ let make_abstract_function_or_global = function
         Some (DExternal (None, flags, name, t, []))
       else
         None
+  | DType (name, flags, _, _) when List.mem Common.AbstractStruct flags ->
+      (* We assume the module doesn't lie and the CAbstractStruct will type-check in C. *)
+      Some (DType (name, List.filter ((<>) Common.AbstractStruct) flags, 0, Forward))
   | d ->
       Some d
 


### PR DESCRIPTION
Needed to compile merkle tree as a standalone project with ease