### PR TITLE
Relax OCaml requirements for karamel

### DIFF
--- a/karamel.opam
+++ b/karamel.opam
@@ -4,7 +4,7 @@ authors: "Jonathan Protzenko <jonathan.protzenko@gmail.com>"
 homepage: "https://github.com/fstarlang/karamel"
 license: "Apache-2.0"
 depends: [
-  "ocaml" {>= "4.08.0" & < "4.13.0"}
+  "ocaml" {>= "4.08.0"}
   "ocamlfind" {build}
   "batteries"
   "zarith"


### PR DESCRIPTION
There doesn't seem to be a reason to require OCaml < 4.13.0 anymore; the opam package seems to work without this upper bound.