### PR TITLE
includes: Fix aligned allocation support for MinGW-W64

### DIFF
--- a/include/krml/internal/target.h
+++ b/include/krml/internal/target.h
@@ -64,16 +64,29 @@
 #  endif
 #endif
 
+/* MinGW-W64 does not support C11 aligned_alloc, but it supports
+ * MSVC's _aligned_malloc.
+ */
 #ifndef KRML_ALIGNED_MALLOC
-#  ifdef _MSC_VER
+#  ifdef __MINGW32__
+#    include <_mingw.h>
+#  endif
+#  if (defined(_MSC_VER) || (defined(__MINGW32__) && defined(__MINGW64_VERSION_MAJOR)))
 #    define KRML_ALIGNED_MALLOC(X, Y) _aligned_malloc(Y, X)
 #  else
 #    define KRML_ALIGNED_MALLOC(X, Y) aligned_alloc(X, Y)
 #  endif
 #endif
 
+/* Since aligned allocations with MinGW-W64 are done with
+ * _aligned_malloc (see above), such pointers must be freed with
+ * _aligned_free.
+ */
 #ifndef KRML_ALIGNED_FREE
-#  ifdef _MSC_VER
+#  ifdef __MINGW32__
+#    include <_mingw.h>
+#  endif
+#  if (defined(_MSC_VER) || (defined(__MINGW32__) && defined(__MINGW64_VERSION_MAJOR)))
 #    define KRML_ALIGNED_FREE(X) _aligned_free(X)
 #  else
 #    define KRML_ALIGNED_FREE(X) free(X)


### PR DESCRIPTION
# Symptoms
I was trying to compile  `dist/gcc-compatible` from the latest HACL* `main` branch with MinGW-W64 (x86_64-w64-mingw32-gcc-11 (GCC) 11.3.0) (to produce a Windows binary release for EverParse, which uses EverCrypt hashing functions), but I failed with error messages complaining about `aligned_alloc` not defined. Thus, I wrote the following C code:
```C
#include "krmllib.h"
#include <stdio.h>

int main() {
  char* test = (char*) KRML_ALIGNED_MALLOC(sizeof(char), 1024);
  if (test != NULL) {
    printf("%d\n", test[2]);
    KRML_ALIGNED_FREE(test);
  }
  return 0;
}
```
which I tried to compile with:
```bash
x86_64-w64-mingw32-gcc.exe -std=gnu11 -I $KRML_HOME/include -I $KRML_HOME/krmllib/dist/minimal test.c
```
There, I got the following error messages:
```
In file included from ../karamel/include/krmllib.h:19,
                 from test.c:1:
test.c: In function ‘main’:
../karamel/include/krml/internal/target.h:71:39: warning: implicit declaration of function ‘aligned_alloc’ [-Wimplicit-function-declaration]
   71 | #    define KRML_ALIGNED_MALLOC(X, Y) aligned_alloc(X, Y)
      |                                       ^~~~~~~~~~~~~
test.c:5:24: note: in expansion of macro ‘KRML_ALIGNED_MALLOC’
    5 |   char* test = (char*) KRML_ALIGNED_MALLOC(sizeof(char), 1024);
      |                        ^~~~~~~~~~~~~~~~~~~
test.c:2:1: note: include ‘<stdlib.h>’ or provide a declaration of ‘aligned_alloc’
    1 | #include "krmllib.h"
  +++ |+#include <stdlib.h>
    2 | #include <stdio.h>
In file included from ../karamel/include/krmllib.h:19,
                 from test.c:1:
../karamel/include/krml/internal/target.h:71:39: warning: incompatible implicit declaration of built-in function ‘aligned_alloc’ [-Wbuiltin-declaration-mismatch]
   71 | #    define KRML_ALIGNED_MALLOC(X, Y) aligned_alloc(X, Y)
      |                                       ^~~~~~~~~~~~~
test.c:5:24: note: in expansion of macro ‘KRML_ALIGNED_MALLOC’
    5 |   char* test = (char*) KRML_ALIGNED_MALLOC(sizeof(char), 1024);
      |                        ^~~~~~~~~~~~~~~~~~~
../karamel/include/krml/internal/target.h:71:39: note: include ‘<stdlib.h>’ or provide a declaration of ‘aligned_alloc’
   71 | #    define KRML_ALIGNED_MALLOC(X, Y) aligned_alloc(X, Y)
      |                                       ^~~~~~~~~~~~~
test.c:5:24: note: in expansion of macro ‘KRML_ALIGNED_MALLOC’
    5 |   char* test = (char*) KRML_ALIGNED_MALLOC(sizeof(char), 1024);
      |                        ^~~~~~~~~~~~~~~~~~~
/usr/lib/gcc/x86_64-w64-mingw32/11/../../../../x86_64-w64-mingw32/bin/ld: /tmp/cc5HCLHE.o:test.c:(.text+0x69): undefined reference to `aligned_alloc'
collect2: error: ld returned 1 exit status
```
# Claim: Cause
When rewriting `test.c` without krmllib:
```C
#include <stdlib.h>
#include <stdio.h>

int main() {
  char* test = (char*) aligned_alloc(sizeof(char), 1024);
  if (test != NULL) {
    printf("%d\n", test[2]);
    free(test);
  }
  return 0;
}

```
and compiling with `x86_64-w64-mingw32-gcc.exe -std=gnu11 test.c`, I got the same error messages.

When looking at the `stdlib.h` provided by MinGW-W64[^1], `aligned_alloc` is not even declared. This explains why `-Wbuiltin-declaration-mismatch` is still reporting a "missing `include <stdlib.h>`" even though I did include it manually.

Then I tried digging in the MinGW-W64 docs, or rather, the lack thereof. Here's what I found:
1. Historically in 2004, MinGW introduced support for MSVC `_aligned_malloc` under the form of `__mingw`-prefixed functions.[^2]
2. Then, in 2007, MinGW-W64 forked out of MinGW.
3. Then, at some point (2010 or before), `__mingw`-prefixed functions ceased to work with MinGW-W64, replaced with `_aligned_malloc` directly following MSVC.[^3][^4]
4. Then, in 2020, MinGW introduced a fix to directly support C11 ` aligned_alloc`[^5].

But the latter fix has not been ported to MinGW-W64 yet, to the best of my knowledge, which would explain the failures I am experiencing.

# Solution: this PR
This PR defines `KRML_ALIGNED_MALLOC` to `_aligned_malloc` for MinGW-W64, following MSVC, taking care of the fact that `_aligned_malloc`-allocated pointers must be freed with `_aligned_free` instead of `free`.

This PR only checks for MinGW-W64, for two reasons:
1. I don't dare to change krmllib's current behavior for MinGW since I can only test MinGW-W64, not MinGW.
2. MinGW now purports to properly support C11 `aligned_alloc`, as stated above.[^5]

To detect MinGW-W64, I am following the documented guidelines[^6], which requires including `_mingw.h` because `__MINGW64_VERSION_MAJOR` is not a compiler-defined macro [^7].

# CI Questions
How do we provide any CI for this? We no longer have Windows CI for Everest at this time, and from what I understand, HACL* CI on Windows only seems to test the MSVC distribution. Should we have a krmllib C test battery (no F*/Z3/OCaml/etc.) to compile and link with MinGW-W64 (and maybe other platforms)? Or should we introduce HACL* CI for MinGW-W64 to just compile `dist/gcc-compatible` there?

# Notes
[^1]: https://sourceforge.net/p/mingw-w64/mingw-w64/ci/master/tree/mingw-w64-headers/crt/stdlib.h
[^2]: https://sourceforge.net/p/mingw/bugs/260/
[^3]: https://sourceforge.net/p/mingw-w64/wiki2/Missing%20_aligned_malloc/
[^4]: https://sourceforge.net/p/mingw-w64/mailman/mingw-w64-public/thread/00d601cb54e4%24feb0d6f0%24fc1284d0%24%40com/#msg26167484
[^5]: https://osdn.net/projects/mingw/ticket/38607
[^6]: https://sourceforge.net/p/mingw-w64/wiki2/Answer%20Check%20For%20Mingw-w64/
[^7]: https://sourceforge.net/p/mingw-w64/discussion/723798/thread/ea355c1f/#d4db