### PR TITLE
Makefile: introduce resource monitoring with $(RESOURCEMONITOR)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ book/_build
 fstar-mode.el
 .#*
 src/Version.ml
+*.runlim

--- a/krmllib/Makefile
+++ b/krmllib/Makefile
@@ -31,7 +31,15 @@ FSTAR_OPTIONS += --record_hints --use_hints --odir $(EXTRACT_DIR) \
 
 INCLUDE_PATHS = ../runtime
 
-FSTAR = $(FSTAR_EXE) $(FSTAR_OPTIONS) --cache_checked_modules --cache_dir obj \
+# Passing RESOURCEMONITOR=1 to this Makefile will create .runlim files
+# throughout the tree with resource information. The $(RUNLIM) variable
+# can also be defined directly if needed. The results can then be
+# tallied with the res_summary.sh script.
+ifneq ($(RESOURCEMONITOR),)
+  RUNLIM = runlim -p -o $@.runlim
+endif
+
+FSTAR = $(RUNLIM) $(FSTAR_EXE) $(FSTAR_OPTIONS) --cache_checked_modules --cache_dir obj \
   --hint_dir hints \
   $(addprefix --include , $(INCLUDE_PATHS)) --cmi \
   --already_cached 'Prims FStar Steel -FStar.Krml.Endianness LowStar -LowStar.Lib'


### PR DESCRIPTION
This introduces a RESOURCEMONITOR variable to the Makefile that causes most rules to generate a .runlim file with information about memory usage, cpu time, and more. The results can then be tallied with the `res_summary.sh` script, currently found in the F* repo.

The same idea is applied to the F* and HACL* repos.

---

F* still uses `$(MON)`, will discuss that in the next F* meeting and possibly change the name. Also, the `res_summary.sh` script could be moved to the everest repo.