### PR TITLE
New internal node for null buffers.

### DIFF
--- a/krmllib/dist/generic/FStar_BV.c
+++ b/krmllib/dist/generic/FStar_BV.c
@@ -18,7 +18,6 @@ Prims_list__bool *FStar_List_Tot_Base_append__bool(Prims_list__bool *x, Prims_li
   {
     Prims_list__bool *tl1 = x->tl;
     bool a1 = x->hd;
-    KRML_CHECK_SIZE(sizeof (Prims_list__bool), (uint32_t)1U);
     Prims_list__bool *buf = KRML_HOST_MALLOC(sizeof (Prims_list__bool));
     buf[0U]
     =
@@ -48,7 +47,6 @@ Prims_list__bool *FStar_Seq_Base_append__bool(Prims_list__bool *s1, Prims_list__
 
 static Prims_list__bool *cons__bool(bool x, Prims_list__bool *s)
 {
-  KRML_CHECK_SIZE(sizeof (Prims_list__bool), (uint32_t)1U);
   Prims_list__bool *buf = KRML_HOST_MALLOC(sizeof (Prims_list__bool));
   buf[0U] = ((Prims_list__bool){ .tag = Prims_Cons, .hd = x, .tl = s });
   return buf;
@@ -58,7 +56,6 @@ Prims_list__bool *FStar_Seq_Base_create__bool(Prims_int len, bool v)
 {
   if (len == (krml_checked_int_t)0)
   {
-    KRML_CHECK_SIZE(sizeof (Prims_list__bool), (uint32_t)1U);
     Prims_list__bool *buf = KRML_HOST_MALLOC(sizeof (Prims_list__bool));
     buf[0U] = ((Prims_list__bool){ .tag = Prims_Nil });
     return buf;
@@ -82,7 +79,6 @@ Prims_int (*FStar_BV_bv2int)(Prims_pos x0, Prims_list__bool *x1) = FStar_UInt_fr
 
 Prims_list__bool *FStar_Seq_Base_empty__bool()
 {
-  KRML_CHECK_SIZE(sizeof (Prims_list__bool), (uint32_t)1U);
   Prims_list__bool *buf = KRML_HOST_MALLOC(sizeof (Prims_list__bool));
   buf[0U] = ((Prims_list__bool){ .tag = Prims_Nil });
   return buf;
@@ -223,7 +219,6 @@ static Prims_list__bool *slice___bool(Prims_list__bool *s, Prims_int i, Prims_in
   }
   else if (j == (krml_checked_int_t)0)
   {
-    KRML_CHECK_SIZE(sizeof (Prims_list__bool), (uint32_t)1U);
     Prims_list__bool *buf = KRML_HOST_MALLOC(sizeof (Prims_list__bool));
     buf[0U] = ((Prims_list__bool){ .tag = Prims_Nil });
     return buf;
@@ -243,14 +238,12 @@ Prims_list__bool *FStar_Seq_Properties_seq_to_list__bool(Prims_list__bool *s)
 {
   if (FStar_Seq_Base_length__bool(s) == (krml_checked_int_t)0)
   {
-    KRML_CHECK_SIZE(sizeof (Prims_list__bool), (uint32_t)1U);
     Prims_list__bool *buf = KRML_HOST_MALLOC(sizeof (Prims_list__bool));
     buf[0U] = ((Prims_list__bool){ .tag = Prims_Nil });
     return buf;
   }
   else
   {
-    KRML_CHECK_SIZE(sizeof (Prims_list__bool), (uint32_t)1U);
     Prims_list__bool *buf = KRML_HOST_MALLOC(sizeof (Prims_list__bool));
     buf[0U]
     =

--- a/krmllib/hints/C.Endianness.fst.hints
+++ b/krmllib/hints/C.Endianness.fst.hints
@@ -8,7 +8,7 @@
       1,
       [ "@query" ],
       0,
-      "25f9201d529504ec4b35dc24481efdc3"
+      "f714d192723ae3cd003b665a306251d4"
     ],
     [
       "C.Endianness.load16_le",
@@ -17,7 +17,7 @@
       1,
       [ "@query" ],
       0,
-      "4b9de1e27dd372e6eea537b031a25ace"
+      "7c36ce76e1d3946caae918ad520e3ff4"
     ],
     [
       "C.Endianness.store16_be",
@@ -26,7 +26,7 @@
       1,
       [ "@query" ],
       0,
-      "1820673a6ad0f5662f81db2a2284f52c"
+      "81317ab67d7faf0d3154b1b9e3255dc4"
     ],
     [
       "C.Endianness.load16_be",
@@ -35,7 +35,7 @@
       1,
       [ "@query" ],
       0,
-      "ad4cce042ca014bc32d93d2079a59426"
+      "0810c1bad382c26054c310ca9339729b"
     ],
     [
       "C.Endianness.store32_le",
@@ -44,7 +44,7 @@
       1,
       [ "@query" ],
       0,
-      "36403b4a58c017d9abaa80361f8bb329"
+      "e7938b98db31b075d84640a86a2349e8"
     ],
     [
       "C.Endianness.load32_le",
@@ -53,7 +53,7 @@
       1,
       [ "@query" ],
       0,
-      "bac3e99388c40a9ff42028b214fe57ce"
+      "d3e47b604fd5e75872e943af652838a3"
     ],
     [
       "C.Endianness.store32_be",
@@ -62,7 +62,7 @@
       1,
       [ "@query" ],
       0,
-      "88a4f0b6d0ec7dc32f9a66c349d61c51"
+      "a541f46cf0fdaf81383be7a35de653dd"
     ],
     [
       "C.Endianness.load32_be",
@@ -71,7 +71,7 @@
       1,
       [ "@query" ],
       0,
-      "82d1e2ddc5994db3975cc9e81f70c94c"
+      "119b6e4df03a70aab30d991c232c5988"
     ],
     [
       "C.Endianness.store64_le",
@@ -80,7 +80,7 @@
       1,
       [ "@query" ],
       0,
-      "f03a813ed732c10d1c9a8fbe2861de14"
+      "9c6833085467264c4b6650ceb4fd3874"
     ],
     [
       "C.Endianness.load64_le",
@@ -89,7 +89,7 @@
       1,
       [ "@query" ],
       0,
-      "a7f69ba3a502f2267ba5a6cc580d4694"
+      "52df04732ae61b6faad361e0a4d4b580"
     ],
     [
       "C.Endianness.load64_be",
@@ -98,7 +98,7 @@
       1,
       [ "@query" ],
       0,
-      "ec6c764a599db0633e589858cc5fb8a4"
+      "c79cf71d1046d757ac342c4a3071aaae"
     ],
     [
       "C.Endianness.store64_be",
@@ -107,7 +107,7 @@
       1,
       [ "@query" ],
       0,
-      "0f538457cda0dc61e910f608241f975b"
+      "dc6bb7c0784c10fca3ea5bdc1b5a7273"
     ],
     [
       "C.Endianness.load128_le",
@@ -119,7 +119,7 @@
         "projection_inverse_BoxInt_proj_0"
       ],
       0,
-      "58a0e8c17d2d77fce0f68a479471f6e1"
+      "caf0b99584f55e158ba7fc56978a317f"
     ],
     [
       "C.Endianness.store128_le",
@@ -131,7 +131,7 @@
         "projection_inverse_BoxInt_proj_0"
       ],
       0,
-      "b74bb23b7c73fe10652e3aeffe2c4234"
+      "81b17ce93aaeeba22f4cb9e14ee07b08"
     ],
     [
       "C.Endianness.load128_be",
@@ -143,7 +143,7 @@
         "projection_inverse_BoxInt_proj_0"
       ],
       0,
-      "40b3de67683ac83b1b13f101848ef9a0"
+      "2b37018ba560aabc7258020e96b43684"
     ],
     [
       "C.Endianness.store128_be",
@@ -155,7 +155,7 @@
         "projection_inverse_BoxInt_proj_0"
       ],
       0,
-      "0d934fc030237468ddb1a7a5e310c1be"
+      "f39d440996001de46464591b898c394f"
     ],
     [
       "C.Endianness.index_32_be",
@@ -219,7 +219,7 @@
         "typing_LowStar.Monotonic.Buffer.loc_none"
       ],
       0,
-      "674cdf0de0fb2db02767359e5302912e"
+      "5fc2f40da78f497984278d97d8fccc77"
     ],
     [
       "C.Endianness.index_32_le",
@@ -281,7 +281,7 @@
         "typing_LowStar.Monotonic.Buffer.loc_none"
       ],
       0,
-      "a568c65a86057390e1f7322f56d9a3a8"
+      "b16fe79afe221f45f7dfed587339aa8a"
     ],
     [
       "C.Endianness.index_64_be",
@@ -344,7 +344,7 @@
         "typing_LowStar.Monotonic.Buffer.loc_none"
       ],
       0,
-      "3e6075310f4b84146dbb529fea014d8b"
+      "15bd2058090968429d1933551015fa54"
     ],
     [
       "C.Endianness.index_64_le",
@@ -404,7 +404,7 @@
         "typing_LowStar.Monotonic.Buffer.loc_none"
       ],
       0,
-      "112dbe3145928f99608b8d12989711b5"
+      "82e6ce2666582d60b97964a914368fb3"
     ],
     [
       "C.Endianness.interval_4_disjoint",
@@ -421,7 +421,7 @@
         "refinement_interpretation_Tm_refine_542f9d4f129664613f2483a6c88bc7c2"
       ],
       0,
-      "db6eaba932d880f2bd271b4c8c8613fd"
+      "d7460a9376771ae78be759f6db051bdb"
     ],
     [
       "C.Endianness.upd_32_be",
@@ -500,7 +500,7 @@
         "typing_LowStar.Monotonic.Buffer.loc_buffer"
       ],
       0,
-      "11f8093093590003cbde7ec4999c6734"
+      "e08d91bfa59e6966e7761f9e5d80fb84"
     ]
   ]
 ]

--- a/krmllib/hints/C.Failure.fst.hints
+++ b/krmllib/hints/C.Failure.fst.hints
@@ -20,7 +20,7 @@
         "typing_FStar.Monotonic.HyperStack.get_hmap"
       ],
       0,
-      "2710d8503d39375c43848ad4b4e76e1c"
+      "8af5b76305b660094a7098a6ec08f831"
     ],
     [
       "C.Failure.failwith",
@@ -29,7 +29,7 @@
       1,
       [ "@query" ],
       0,
-      "1a3df2dde16d509d2dab7a9ca03508f2"
+      "3c94d668ca81e7bf0401a0d1ba0b9106"
     ]
   ]
 ]

--- a/krmllib/hints/C.Loops.fst.hints
+++ b/krmllib/hints/C.Loops.fst.hints
@@ -20,7 +20,7 @@
         "typing_FStar.UInt32.v"
       ],
       0,
-      "cf87a2eedeff2365bde2de5c22667794"
+      "93a5ba493ad42cfa2e406913af18ca2e"
     ],
     [
       "C.Loops.for",
@@ -40,7 +40,7 @@
         "typing_FStar.UInt32.v"
       ],
       0,
-      "6e6833388c89f0817d48b4c883af1119"
+      "7d69dfb6c5f1a46cee6a308f08834d49"
     ],
     [
       "C.Loops.for",
@@ -80,7 +80,7 @@
         "typing_FStar.Monotonic.HyperStack.get_tip", "typing_FStar.UInt32.v"
       ],
       0,
-      "c560312f4b484cbc954c8a52472f4770"
+      "27766a295c1838d17782f195fe2a5ad3"
     ],
     [
       "C.Loops.for64",
@@ -101,7 +101,7 @@
         "typing_FStar.UInt64.v"
       ],
       0,
-      "e76bc74140bccc30ce7d306ffbcf7ac0"
+      "bbbe7a2f2b2a71661dbeaa6d2944889e"
     ],
     [
       "C.Loops.for64",
@@ -121,7 +121,7 @@
         "typing_FStar.UInt64.v"
       ],
       0,
-      "dcad1966592b64557f54a8f50a1d0a33"
+      "3433469b646dd5bf4664204bbb6e8225"
     ],
     [
       "C.Loops.for64",
@@ -161,7 +161,7 @@
         "typing_FStar.Monotonic.HyperStack.get_tip", "typing_FStar.UInt64.v"
       ],
       0,
-      "d9e983f35f0cdfdad54f6f2c4148372e"
+      "36244dff1c5ccd27aa3db0b6901a84ed"
     ],
     [
       "C.Loops.reverse_for",
@@ -183,7 +183,7 @@
         "typing_FStar.UInt32.v"
       ],
       0,
-      "71282c77db947faf8aef39145364b96c"
+      "2b844a2ef9d40c05cfd6500b1f522c02"
     ],
     [
       "C.Loops.reverse_for",
@@ -205,7 +205,7 @@
         "typing_FStar.UInt32.v"
       ],
       0,
-      "aa644fb80130f73c150b4ad65c207175"
+      "a0a929ac5d4b211cc37c33fa5b500762"
     ],
     [
       "C.Loops.reverse_for",
@@ -246,7 +246,7 @@
         "typing_FStar.Monotonic.HyperStack.get_tip", "typing_FStar.UInt32.v"
       ],
       0,
-      "f7e575d0f58bc6f18e0da72a5e1c320d"
+      "e98a099a780ed6acf445fa5c6a49a65d"
     ],
     [
       "C.Loops.interruptible_for",
@@ -266,7 +266,7 @@
         "typing_FStar.UInt32.v"
       ],
       0,
-      "b6515b3b5cd496d4f8fd1dea28fc99f5"
+      "2b167261376238602293dc153f067f43"
     ],
     [
       "C.Loops.interruptible_for",
@@ -286,7 +286,7 @@
         "typing_FStar.UInt32.v"
       ],
       0,
-      "6d6cec1b3b15d9c713c1ec41627ad04f"
+      "75281b9affda99416891e0a6193d3da9"
     ],
     [
       "C.Loops.interruptible_for",
@@ -330,7 +330,7 @@
         "typing_FStar.Monotonic.HyperStack.get_tip", "typing_FStar.UInt32.v"
       ],
       0,
-      "bea1878016a2c5656abfe9ec7ca7fcf1"
+      "93a14e0145d703aed5475c32b041f27e"
     ],
     [
       "C.Loops.do_while",
@@ -355,7 +355,7 @@
         "typing_FStar.Monotonic.HyperStack.get_tip"
       ],
       0,
-      "b9afb1b023cfbafca9753bac78ed9f7e"
+      "9ffb352af1c6852a0b305e885d3c5d69"
     ],
     [
       "C.Loops.while",
@@ -369,7 +369,7 @@
         "refinement_interpretation_Tm_refine_b16bf82b210653a34e4d7322fab91ffb"
       ],
       0,
-      "e7b660d3ad58f855e3a2c9ee121b9bf7"
+      "204886de152658deab5dbe718a66efde"
     ],
     [
       "C.Loops.interruptible_reverse_for",
@@ -391,7 +391,7 @@
         "typing_FStar.UInt32.v"
       ],
       0,
-      "fb6317905a75707bfd8da194a115c6b8"
+      "272210f6fa34516584cb2e55c4555351"
     ],
     [
       "C.Loops.interruptible_reverse_for",
@@ -413,7 +413,7 @@
         "typing_FStar.UInt32.v"
       ],
       0,
-      "27a07327b2ff9b2cad63c6fe01a85820"
+      "82501314e715940fa77409a6d588138a"
     ],
     [
       "C.Loops.interruptible_reverse_for",
@@ -458,7 +458,7 @@
         "typing_FStar.Monotonic.HyperStack.get_tip", "typing_FStar.UInt32.v"
       ],
       0,
-      "f6d2729467d2426c90b34312e386e642"
+      "07f00f614a97abb011b13bdba312c137"
     ],
     [
       "C.Loops.map",
@@ -467,7 +467,7 @@
       1,
       [ "@query" ],
       0,
-      "d97afd5b4707aa8e18be014353c7427e"
+      "542d44709663da66ff060fa48ccaee72"
     ],
     [
       "C.Loops.map",
@@ -476,7 +476,7 @@
       1,
       [ "@query" ],
       0,
-      "4c8fb4d4cc8b7043292437c1d1fcb00e"
+      "af00ebcdda0e122489ed4cdcda6f446c"
     ],
     [
       "C.Loops.map",
@@ -525,7 +525,7 @@
         "typing_Spec.Loops.seq_map"
       ],
       0,
-      "6578bcc8b7852bbc33b8f415d910a011"
+      "cb5cc0ac6bf397267c6bb6e811df6b9a"
     ],
     [
       "C.Loops.map2",
@@ -540,7 +540,7 @@
         "typing_LowStar.Buffer.trivial_preorder"
       ],
       0,
-      "96b44ffa5bf8acc5c1c925a14def7d0d"
+      "e72be760e81c09204e6726b9106df68f"
     ],
     [
       "C.Loops.map2",
@@ -549,7 +549,7 @@
       1,
       [ "@query" ],
       0,
-      "68037f1e6f293a0cd86b1f415246dd0d"
+      "815b390eff92c351a2846ddd7ae764d6"
     ],
     [
       "C.Loops.map2",
@@ -598,7 +598,7 @@
         "typing_LowStar.Monotonic.Buffer.loc_buffer"
       ],
       0,
-      "e03b6f45e525ead7bf269367155fc9bd"
+      "1dd9122ed342a7ae41ffd5a209a4da89"
     ],
     [
       "C.Loops.in_place_map",
@@ -607,7 +607,7 @@
       1,
       [ "@query" ],
       0,
-      "c159fd6e2dc1b1cd1f0d3e0561d25ef7"
+      "9ecd6603302646b52233675052fe3635"
     ],
     [
       "C.Loops.in_place_map",
@@ -616,7 +616,7 @@
       1,
       [ "@query" ],
       0,
-      "e0622e94135ada24871a8dbd60db463d"
+      "1ef2e2479402bbfa756d91f8e8443574"
     ],
     [
       "C.Loops.in_place_map",
@@ -661,7 +661,7 @@
         "typing_Spec.Loops.seq_map"
       ],
       0,
-      "3ed600c326370177e5561ea8efac67b5"
+      "653ff50ec57c279938c30ae714da002d"
     ],
     [
       "C.Loops.in_place_map2",
@@ -676,7 +676,7 @@
         "typing_LowStar.Buffer.trivial_preorder"
       ],
       0,
-      "bf08d00c3d87a60e69caf341019312cd"
+      "dd2e5854ec99eefe79b1c38bf031db4d"
     ],
     [
       "C.Loops.in_place_map2",
@@ -685,7 +685,7 @@
       1,
       [ "@query" ],
       0,
-      "9bd09782fc8582f438d84fb513c2be4d"
+      "d2643af7a8677e53f04555a55ebf93d2"
     ],
     [
       "C.Loops.in_place_map2",
@@ -732,7 +732,7 @@
         "typing_LowStar.Monotonic.Buffer.loc_buffer"
       ],
       0,
-      "f2ebd1448f4e656052d03443138dbc5a"
+      "225c531ff815ef540903c3ccadd9632c"
     ],
     [
       "C.Loops.repeat",
@@ -755,7 +755,7 @@
         "typing_LowStar.Buffer.trivial_preorder"
       ],
       0,
-      "2746ae562d4ff51c6f18f8e587bdeeee"
+      "bb6ddf8425a806fe9096f3ccb0dd8402"
     ],
     [
       "C.Loops.repeat",
@@ -773,7 +773,7 @@
         "typing_LowStar.Buffer.trivial_preorder"
       ],
       0,
-      "6f1e077a10cd571ecd721c60c3c4b77d"
+      "08906eaff9289007c06e7e96677ed71f"
     ],
     [
       "C.Loops.repeat",
@@ -806,7 +806,7 @@
         "typing_LowStar.Monotonic.Buffer.loc_buffer"
       ],
       0,
-      "a40d922321567275d9fa1fd260f26fe2"
+      "897671071862a5e6c08c4fcb48ae8cf4"
     ],
     [
       "C.Loops.repeat_range_body_impl",
@@ -820,7 +820,7 @@
         "projection_inverse_BoxBool_proj_0"
       ],
       0,
-      "5e2d18b736468c71d6478353440cd5bb"
+      "cf590d112bc42595d5c64f71d2c68c57"
     ],
     [
       "C.Loops.repeat_range_body_impl",
@@ -839,7 +839,7 @@
         "typing_FStar.UInt32.v"
       ],
       0,
-      "c3153b5a3dd9cd6c974d1042ed420459"
+      "29334a4a4b2e166cd07f6c7c2193900a"
     ],
     [
       "C.Loops.repeat_range",
@@ -858,7 +858,7 @@
         "typing_FStar.UInt32.v"
       ],
       0,
-      "1294a43aceaab89a5b2e235a3d55cf8e"
+      "18b9edafd45b696fbb392977f43f8cf1"
     ],
     [
       "C.Loops.repeat_range",
@@ -872,7 +872,7 @@
         "projection_inverse_BoxBool_proj_0"
       ],
       0,
-      "cdbc5dd4b9756126e2f0d3b6f4a2b25b"
+      "8c07efce27acc708e8df0419ce832cb3"
     ],
     [
       "C.Loops.repeat_range",
@@ -897,7 +897,7 @@
         "typing_FStar.UInt32.v"
       ],
       0,
-      "d691fddc68f27109f6905981ceb5e29f"
+      "68a84fd825529610375c90e0a738033f"
     ],
     [
       "C.Loops.total_while_gen",
@@ -912,7 +912,7 @@
         "equality_tok_Prims.LexTop@tok", "typing_tok_Prims.LexTop@tok"
       ],
       0,
-      "553cc0eb7906bc778b904feed23d598f"
+      "38ece3badd7aa3e79be066a7f9c3353f"
     ],
     [
       "C.Loops.total_while",
@@ -932,7 +932,7 @@
         "well-founded-ordering-on-nat"
       ],
       0,
-      "59f968b78faf37d90eac36065417cf6b"
+      "4033189f66451c464fce2579a35b4b6e"
     ]
   ]
 ]

--- a/krmllib/hints/C.String.fst.hints
+++ b/krmllib/hints/C.String.fst.hints
@@ -11,7 +11,7 @@
         "primitive_Prims.op_Subtraction", "projection_inverse_BoxInt_proj_0"
       ],
       0,
-      "f55298c30851eacb3a094716fecdfcc2"
+      "1fbea53384786d38ade36c1e0698102d"
     ],
     [
       "C.String.well_formed",
@@ -23,7 +23,7 @@
         "primitive_Prims.op_Subtraction", "projection_inverse_BoxInt_proj_0"
       ],
       0,
-      "d5ea6e0e7e15bbd5f9330dd3afdf3633"
+      "7fc6b69b827219e31c6d35a7edc0f886"
     ],
     [
       "C.String.t",
@@ -35,7 +35,7 @@
         "lemma_FStar.Seq.Base.hasEq_lemma"
       ],
       0,
-      "6afa053eb3ddd5545f9203c1d9fd5e62"
+      "b40dfd543edb1251064c7026a65f4c1b"
     ],
     [
       "C.String.length",
@@ -50,7 +50,7 @@
         "refinement_interpretation_Tm_refine_ed6e8a85e123e1e628ba0dad885f3031"
       ],
       0,
-      "13be36548892ea6ae2e39d3281206f0c"
+      "156ada99a0db03614b34e832153e6324"
     ],
     [
       "C.String.get",
@@ -66,7 +66,7 @@
         "refinement_interpretation_Tm_refine_dfcb8c150fd42ce38050af33905be19c"
       ],
       0,
-      "a5275a0519ab731400f93e26e1450719"
+      "de6e7d7f8b3d4afb947fb67609e8eb5b"
     ],
     [
       "C.String.get",
@@ -85,7 +85,7 @@
         "typing_FStar.UInt32.v"
       ],
       0,
-      "574c63dea6b4ec1ae5753663d5a71126"
+      "868879fa4e012acd78d4d210d6aac50b"
     ],
     [
       "C.String.nonzero_is_lt",
@@ -98,7 +98,7 @@
         "fuel_guarded_inversion_C.String.t"
       ],
       0,
-      "7e3682da55bc3e5d4a9d82df6ad02a58"
+      "ca350570c3a891a98074bb91fcc69bca"
     ],
     [
       "C.String.nonzero_is_lt",
@@ -119,7 +119,7 @@
         "typing_FStar.UInt32.v"
       ],
       0,
-      "0f57266520bc136594ebe682b5f9efb7"
+      "3fc0f1027a5c7afcc1e1e33506d06789"
     ],
     [
       "C.String.memcpy",
@@ -133,7 +133,7 @@
         "typing_FStar.UInt8.t"
       ],
       0,
-      "b1927c24c94a901006649ba660bb7259"
+      "3c80e447d35c928d40aa30de63820488"
     ]
   ]
 ]

--- a/krmllib/hints/C.String.fsti.hints
+++ b/krmllib/hints/C.String.fsti.hints
@@ -11,7 +11,7 @@
         "primitive_Prims.op_Subtraction", "projection_inverse_BoxInt_proj_0"
       ],
       0,
-      "2b3ed5357cdac067d54251ff9fa8190e"
+      "ea4a8746dabc301de677a84ded239885"
     ],
     [
       "C.String.well_formed",
@@ -23,7 +23,7 @@
         "primitive_Prims.op_Subtraction", "projection_inverse_BoxInt_proj_0"
       ],
       0,
-      "b8a39b75be448990f69c25a51d1f5810"
+      "0b7cb1d10c78881df7252dc466672f5c"
     ],
     [
       "C.String.get",
@@ -39,7 +39,7 @@
         "refinement_interpretation_Tm_refine_dfcb8c150fd42ce38050af33905be19c"
       ],
       0,
-      "06e97ba686202f2b4363fb1d36936a03"
+      "a2b60faab6684ccebb440cdf3d25acb6"
     ],
     [
       "C.String.nonzero_is_lt",
@@ -52,7 +52,7 @@
         "typing_C.String.length"
       ],
       0,
-      "2adc26c00d65ad282af2b6e045dfce83"
+      "0e25b33fc70792ae12a5ec67ad959be5"
     ],
     [
       "C.String.memcpy",
@@ -66,7 +66,7 @@
         "typing_FStar.UInt8.t"
       ],
       0,
-      "dbee94259fd09d934af7e63d96ab2d3b"
+      "6949e15ed3e6a9653da456843e958e4b"
     ]
   ]
 ]

--- a/krmllib/hints/C.fst.hints
+++ b/krmllib/hints/C.fst.hints
@@ -8,7 +8,7 @@
       1,
       [ "@query", "assumption_C.HasEq_char" ],
       0,
-      "f6b2616350a1afd218591405fda5dbfc"
+      "a8043dfcc8190c8b9d594abb12ba0fca"
     ]
   ]
 ]

--- a/krmllib/hints/FStar.Krml.Endianness.fst.hints
+++ b/krmllib/hints/FStar.Krml.Endianness.fst.hints
@@ -32,7 +32,7 @@
         "well-founded-ordering-on-nat"
       ],
       0,
-      "f8ee26dfbf08379cbcedd504be354d1e"
+      "a835814a90559a4493be134588aff739"
     ],
     [
       "FStar.Krml.Endianness.be_to_n",
@@ -65,7 +65,7 @@
         "well-founded-ordering-on-nat"
       ],
       0,
-      "f0c7576a9dad610102d2304b13946737"
+      "186c11d6a1e3cc5e2eb6df29adaf8e6b"
     ],
     [
       "FStar.Krml.Endianness.lemma_euclidean_division",
@@ -77,7 +77,7 @@
         "primitive_Prims.op_Multiply", "projection_inverse_BoxInt_proj_0"
       ],
       0,
-      "7fd97e0fe10d7ee459a147710544a976"
+      "02cc61aa30a4ac56d39621361ee08635"
     ],
     [
       "FStar.Krml.Endianness.lemma_factorise",
@@ -89,7 +89,7 @@
         "primitive_Prims.op_Multiply", "projection_inverse_BoxInt_proj_0"
       ],
       0,
-      "f31c94666a4cab39000be6d15cfc000b"
+      "a24e2ba000d32f5ac09c2e438998ad88"
     ],
     [
       "FStar.Krml.Endianness.lemma_le_to_n_is_bounded",
@@ -106,7 +106,7 @@
         "typing_FStar.Seq.Base.length", "typing_FStar.UInt8.t"
       ],
       0,
-      "9382020b78858038768280e4d0fb30d4"
+      "9e81561b95dbf5d8971ad7d0956ec80b"
     ],
     [
       "FStar.Krml.Endianness.lemma_le_to_n_is_bounded",
@@ -124,7 +124,7 @@
         "typing_FStar.Seq.Base.length", "typing_FStar.UInt8.t"
       ],
       0,
-      "98f878a2f46b4bb1ad46f8960558e152"
+      "f6f1ac9afbcf4cd968c7b5f2c53676fb"
     ],
     [
       "FStar.Krml.Endianness.lemma_le_to_n_is_bounded",
@@ -166,7 +166,7 @@
         "typing_Prims.pow2", "well-founded-ordering-on-nat"
       ],
       0,
-      "c06017dd9bb6fbe8f6e668c8d224be66"
+      "74f1479ade3ebc979e7e47b5d7f6d53b"
     ],
     [
       "FStar.Krml.Endianness.lemma_be_to_n_is_bounded",
@@ -183,7 +183,7 @@
         "typing_FStar.Seq.Base.length", "typing_FStar.UInt8.t"
       ],
       0,
-      "536eb13695c360b68d31f5a67fbf8cbf"
+      "ff837c10133e37c62cf6aed4c5f5913d"
     ],
     [
       "FStar.Krml.Endianness.lemma_be_to_n_is_bounded",
@@ -201,7 +201,7 @@
         "typing_FStar.Seq.Base.length", "typing_FStar.UInt8.t"
       ],
       0,
-      "524300c50ec61acec60e6935df8c0030"
+      "b79b82e5d4475c2835b18635a0d24c39"
     ],
     [
       "FStar.Krml.Endianness.lemma_be_to_n_is_bounded",
@@ -240,7 +240,7 @@
         "typing_Prims.pow2", "well-founded-ordering-on-nat"
       ],
       0,
-      "606e558d01463722c3ab28a0d855a9da"
+      "05fe6a16c8cf8d4b1a20f5b49bf6e0b4"
     ],
     [
       "FStar.Krml.Endianness.n_to_le",
@@ -259,7 +259,7 @@
         "typing_FStar.UInt32.v"
       ],
       0,
-      "c62b7b00abe1008f47ed9756127f7b69"
+      "0c068a9ac8857de5a7fa03e5da44de03"
     ],
     [
       "FStar.Krml.Endianness.n_to_le",
@@ -278,7 +278,7 @@
         "typing_FStar.UInt32.v"
       ],
       0,
-      "66905979d4009a496f159f6c8fa4528d"
+      "2d65bea451c93ae696e076f22b23efef"
     ],
     [
       "FStar.Krml.Endianness.n_to_le",
@@ -341,7 +341,7 @@
         "typing_FStar.UInt8.t", "well-founded-ordering-on-nat"
       ],
       0,
-      "d04c104bd4e22f0092a5f8144d76388f"
+      "f51b8d70c6ee7d21f7d54acfecb6f1a5"
     ],
     [
       "FStar.Krml.Endianness.n_to_be",
@@ -360,7 +360,7 @@
         "typing_FStar.UInt32.v"
       ],
       0,
-      "bea974255bef16ef0222d24fe7367aaf"
+      "c6e3aa840744fab22afc7824cd9e25dd"
     ],
     [
       "FStar.Krml.Endianness.n_to_be",
@@ -379,7 +379,7 @@
         "typing_FStar.UInt32.v"
       ],
       0,
-      "b3c998fbf8f2f3e5bb586e313e9a99cc"
+      "202edd8b8ec2783949b4d0dce02da9dc"
     ],
     [
       "FStar.Krml.Endianness.n_to_be",
@@ -442,7 +442,7 @@
         "well-founded-ordering-on-nat"
       ],
       0,
-      "55f4b5df6f341cb9eca3a348b6d465d5"
+      "e3bd1895ba087c5671cfc68ae6d72d3d"
     ],
     [
       "FStar.Krml.Endianness.n_to_le_inj",
@@ -461,7 +461,7 @@
         "typing_FStar.UInt32.v"
       ],
       0,
-      "8b3b6fbac2b2a6eb4183cf7dd3a0d698"
+      "c34a59b56c24184daaa59c9ab3eb237a"
     ],
     [
       "FStar.Krml.Endianness.n_to_le_inj",
@@ -483,7 +483,7 @@
         "typing_FStar.Krml.Endianness.n_to_le", "typing_FStar.UInt32.v"
       ],
       0,
-      "09cfe39b0cadc1be6087cc2674376223"
+      "f326bb8b8561b30cfb46440d999f6cd7"
     ],
     [
       "FStar.Krml.Endianness.n_to_be_inj",
@@ -502,7 +502,7 @@
         "typing_FStar.UInt32.v"
       ],
       0,
-      "d6d792bdf419c7bea44fac0739975667"
+      "cade0b67d130acd227f5b556332f750f"
     ],
     [
       "FStar.Krml.Endianness.n_to_be_inj",
@@ -524,7 +524,7 @@
         "typing_FStar.Krml.Endianness.n_to_be", "typing_FStar.UInt32.v"
       ],
       0,
-      "b181b71f7e75ec485d96e90581dd0608"
+      "9a3ed304f3374be937ec7b19165d21d2"
     ],
     [
       "FStar.Krml.Endianness.be_to_n_inj",
@@ -580,7 +580,7 @@
         "well-founded-ordering-on-nat"
       ],
       0,
-      "074bc3e7a9c4e398a037da095a286b0d"
+      "7f34f28c468bbfb92c877dc4d3c5b453"
     ],
     [
       "FStar.Krml.Endianness.le_to_n_inj",
@@ -637,7 +637,7 @@
         "typing_FStar.UInt8.v", "well-founded-ordering-on-nat"
       ],
       0,
-      "402226f7c38ff6d6a13c70342255db72"
+      "beb22399b15d91abb43622128788ea83"
     ],
     [
       "FStar.Krml.Endianness.n_to_be_be_to_n",
@@ -656,7 +656,7 @@
         "typing_FStar.Seq.Base.length", "typing_FStar.UInt8.t"
       ],
       0,
-      "d78ea75cb14025d8d8eef0ccb12d9bdc"
+      "a45423f808ce24ab3bd131a9e5c8cda8"
     ],
     [
       "FStar.Krml.Endianness.n_to_le_le_to_n",
@@ -675,7 +675,7 @@
         "typing_FStar.Seq.Base.length", "typing_FStar.UInt8.t"
       ],
       0,
-      "71fb96c1cbde8e87a56085ed10cf605c"
+      "d014ad8b276ac4b90a16940c658aac5d"
     ],
     [
       "FStar.Krml.Endianness.uint32_of_le",
@@ -695,7 +695,7 @@
         "refinement_interpretation_Tm_refine_073e087ab5f9fabfeddf43c4ff72a1d0"
       ],
       0,
-      "06e1acf209566fa3ef65e13794abeab1"
+      "986a4c8fa941a1e9927ca0b23d634fbc"
     ],
     [
       "FStar.Krml.Endianness.le_of_uint32",
@@ -712,7 +712,7 @@
         "projection_inverse_BoxInt_proj_0"
       ],
       0,
-      "75802e32b618b287bc47e918981b993e"
+      "898fc00048848249245f7f5925c0fc06"
     ],
     [
       "FStar.Krml.Endianness.uint32_of_be",
@@ -732,7 +732,7 @@
         "refinement_interpretation_Tm_refine_073e087ab5f9fabfeddf43c4ff72a1d0"
       ],
       0,
-      "56ad39f04b85e8d4d66c27efe1e44ee8"
+      "16d65b09559046b836cc167f6baf08f6"
     ],
     [
       "FStar.Krml.Endianness.be_of_uint32",
@@ -749,7 +749,7 @@
         "projection_inverse_BoxInt_proj_0"
       ],
       0,
-      "c6f561cc3943cded8acb198e042336c4"
+      "5e30362d0f7d4842cfb7410cbf17b0b0"
     ],
     [
       "FStar.Krml.Endianness.uint64_of_le",
@@ -769,7 +769,7 @@
         "refinement_interpretation_Tm_refine_1cb22d5b190a69600ef23f524d7a6d8a"
       ],
       0,
-      "b3a1f0414a3cd83ef8a4b685bf6f5655"
+      "590cb06980f7e936b6f15d66eeaab3d3"
     ],
     [
       "FStar.Krml.Endianness.le_of_uint64",
@@ -786,7 +786,7 @@
         "projection_inverse_BoxInt_proj_0"
       ],
       0,
-      "560dc5db648cf9af8211b756925e72ab"
+      "d579cb6cf8d433a2b16e31d21ae08ac9"
     ],
     [
       "FStar.Krml.Endianness.uint64_of_be",
@@ -806,7 +806,7 @@
         "refinement_interpretation_Tm_refine_1cb22d5b190a69600ef23f524d7a6d8a"
       ],
       0,
-      "9677442f1cf02112b0327aaa8de2e0a0"
+      "026867acd0ca940969ac1335884d15b1"
     ],
     [
       "FStar.Krml.Endianness.be_of_uint64",
@@ -823,7 +823,7 @@
         "projection_inverse_BoxInt_proj_0"
       ],
       0,
-      "eac666198258df11e678f043006e2f5b"
+      "076d553462eea45932004bd33396247c"
     ],
     [
       "FStar.Krml.Endianness.seq_uint32_of_le",
@@ -837,7 +837,7 @@
         "refinement_interpretation_Tm_refine_414d0a9f578ab0048252f8c8f552b99f"
       ],
       0,
-      "75c9a5089a719577ff0d794822f65806"
+      "2455c3eaea2735cad12b379a1aca5438"
     ],
     [
       "FStar.Krml.Endianness.seq_uint32_of_le",
@@ -877,7 +877,7 @@
         "well-founded-ordering-on-nat"
       ],
       0,
-      "e2bbc1390096c32d325719ada973eab9"
+      "9ff259ef41d425f0031c1c377ff59be3"
     ],
     [
       "FStar.Krml.Endianness.le_of_seq_uint32",
@@ -913,7 +913,7 @@
         "well-founded-ordering-on-nat"
       ],
       0,
-      "7fc1bf2cf325f23e50a6b7a98da7d1d6"
+      "286baea0b63efa24ad452f32be68d00b"
     ],
     [
       "FStar.Krml.Endianness.seq_uint32_of_be",
@@ -927,7 +927,7 @@
         "refinement_interpretation_Tm_refine_414d0a9f578ab0048252f8c8f552b99f"
       ],
       0,
-      "cae4a029466341bfe14d6e702cfa9b2c"
+      "053d4d65caa40759de0d84d4c9688e08"
     ],
     [
       "FStar.Krml.Endianness.seq_uint32_of_be",
@@ -967,7 +967,7 @@
         "well-founded-ordering-on-nat"
       ],
       0,
-      "d7b3ca04e21c68b775d1a5328c8edc75"
+      "77af270c82104e3cf59ec1a0fba3c9d9"
     ],
     [
       "FStar.Krml.Endianness.be_of_seq_uint32",
@@ -1003,7 +1003,7 @@
         "well-founded-ordering-on-nat"
       ],
       0,
-      "4791e557d23da6002385f0f6bb705e22"
+      "714c843fb6c448230e440c202a1d9382"
     ],
     [
       "FStar.Krml.Endianness.seq_uint64_of_le",
@@ -1017,7 +1017,7 @@
         "refinement_interpretation_Tm_refine_414d0a9f578ab0048252f8c8f552b99f"
       ],
       0,
-      "dfc8094cab9bcebf1552d221d875cbab"
+      "ee551ad4d60f2003ab792f8c23b17a47"
     ],
     [
       "FStar.Krml.Endianness.seq_uint64_of_le",
@@ -1057,7 +1057,7 @@
         "well-founded-ordering-on-nat"
       ],
       0,
-      "da0dd6818b06eca221d612ac07aeed6b"
+      "e1cde203fc8e7e9027da2ad85ac0e396"
     ],
     [
       "FStar.Krml.Endianness.le_of_seq_uint64",
@@ -1093,7 +1093,7 @@
         "well-founded-ordering-on-nat"
       ],
       0,
-      "02cd51099ac0f29168f8e84edc46ac8b"
+      "ab7d402c71727cd3468bdc5f38288df8"
     ],
     [
       "FStar.Krml.Endianness.seq_uint64_of_be",
@@ -1107,7 +1107,7 @@
         "refinement_interpretation_Tm_refine_414d0a9f578ab0048252f8c8f552b99f"
       ],
       0,
-      "e59e2f07aa1b0a98f095bd14a7ed759f"
+      "029f44f3592acf385b41ea474e5d36a7"
     ],
     [
       "FStar.Krml.Endianness.seq_uint64_of_be",
@@ -1147,7 +1147,7 @@
         "well-founded-ordering-on-nat"
       ],
       0,
-      "450d07258f522b49cbf6bf1a283b47b1"
+      "d9d6793e934bf75ce9751c2a9adcd21b"
     ],
     [
       "FStar.Krml.Endianness.be_of_seq_uint64",
@@ -1183,7 +1183,7 @@
         "well-founded-ordering-on-nat"
       ],
       0,
-      "dc23e8e768b212adcb8d8b3b044fa34c"
+      "1c5eaf0241f82c97c6ade7bd767837c1"
     ],
     [
       "FStar.Krml.Endianness.offset_uint32_be",
@@ -1209,7 +1209,7 @@
         "typing_FStar.UInt8.t"
       ],
       0,
-      "99f96b6a9b666af754e035175b1b092c"
+      "796270ad78903c3e8e2bfdee2df83d5f"
     ],
     [
       "FStar.Krml.Endianness.offset_uint32_be",
@@ -1278,7 +1278,7 @@
         "well-founded-ordering-on-nat"
       ],
       0,
-      "cbfc95ad0dbcea3ab540ee7945df6959"
+      "32dd4543754cc0e47aba022d7beb3332"
     ],
     [
       "FStar.Krml.Endianness.offset_uint32_le",
@@ -1304,7 +1304,7 @@
         "typing_FStar.UInt8.t"
       ],
       0,
-      "13b5f29cd33dc9f1ea83de3c58418465"
+      "d0bd90c1df1afbda835ea1274b992d12"
     ],
     [
       "FStar.Krml.Endianness.offset_uint32_le",
@@ -1371,7 +1371,7 @@
         "well-founded-ordering-on-nat"
       ],
       0,
-      "d401ce2b9cf0e8cf784eb910a718fbe3"
+      "bfd4f925e9234da834e6a6194c222456"
     ],
     [
       "FStar.Krml.Endianness.offset_uint64_be",
@@ -1397,7 +1397,7 @@
         "typing_FStar.UInt8.t"
       ],
       0,
-      "80373bdc26353aca91f1033ff1762dc5"
+      "edbecfec1f6922d18f9582305fb2cc06"
     ],
     [
       "FStar.Krml.Endianness.offset_uint64_be",
@@ -1466,7 +1466,7 @@
         "well-founded-ordering-on-nat"
       ],
       0,
-      "a463a22665c030cd4111db30ae926a7c"
+      "5e36c79443b242e0724048a483406a57"
     ],
     [
       "FStar.Krml.Endianness.offset_uint64_le",
@@ -1492,7 +1492,7 @@
         "typing_FStar.UInt8.t"
       ],
       0,
-      "8464ca49bccb872b6b1268709bc32065"
+      "d666893bb740969d65e843426cfecd79"
     ],
     [
       "FStar.Krml.Endianness.offset_uint64_le",
@@ -1564,7 +1564,7 @@
         "well-founded-ordering-on-nat"
       ],
       0,
-      "2f1157860004d15c36225bfa2512afac"
+      "e906b3d9378704bae861c8b0b8cf07b6"
     ],
     [
       "FStar.Krml.Endianness.tail_cons",
@@ -1598,7 +1598,7 @@
         "typing_FStar.Seq.Properties.tail"
       ],
       0,
-      "edd6bf754b4da0098e1fb899c983a2f2"
+      "a4001901be06e2df5cd0fc27ffa0ec1c"
     ],
     [
       "FStar.Krml.Endianness.be_of_seq_uint32_append",
@@ -1672,7 +1672,7 @@
         "well-founded-ordering-on-nat"
       ],
       0,
-      "722c8a5e614855cd317d7bd6775de15a"
+      "ee3837f288db32bb875f206c1a81428b"
     ],
     [
       "FStar.Krml.Endianness.be_of_seq_uint32_base",
@@ -1728,7 +1728,7 @@
         "typing_FStar.UInt8.t"
       ],
       0,
-      "1fbb917fb6da770194560dcd61b6d80a"
+      "3343d0344a3b7bc1e80536f8899cf1b3"
     ],
     [
       "FStar.Krml.Endianness.le_of_seq_uint32_append",
@@ -1791,7 +1791,7 @@
         "typing_FStar.UInt8.t", "well-founded-ordering-on-nat"
       ],
       0,
-      "6d3333d23b001a898ba1da512ca92848"
+      "e73d29948ad24f969ae3ac955536ed2a"
     ],
     [
       "FStar.Krml.Endianness.le_of_seq_uint32_base",
@@ -1847,7 +1847,7 @@
         "typing_FStar.UInt8.t"
       ],
       0,
-      "247686c6c378ebe4e75980e98ff5aa3a"
+      "e39b38503b123d5cc7f2fc130c431807"
     ],
     [
       "FStar.Krml.Endianness.be_of_seq_uint64_append",
@@ -1928,7 +1928,7 @@
         "well-founded-ordering-on-nat"
       ],
       0,
-      "4aa50d92449e418e3ed9ba5891610d0b"
+      "275cfd03483e94942c3ad9d7e0d8c4df"
     ],
     [
       "FStar.Krml.Endianness.be_of_seq_uint64_base",
@@ -1986,7 +1986,7 @@
         "typing_FStar.UInt8.t", "typing_Prims.pow2"
       ],
       0,
-      "b3d17de1c136702bc7ff9236c72f8cd0"
+      "6f5e95029dea171fab7abafce022f68b"
     ],
     [
       "FStar.Krml.Endianness.seq_uint32_of_be_be_of_seq_uint32",
@@ -1998,7 +1998,7 @@
         "refinement_interpretation_Tm_refine_a84773c2eb377e624aba800b71ec3ba0"
       ],
       0,
-      "bfc33524db2cf64e57ebc1e2a11c9f22"
+      "9f0f9fad20af439e0e692998973cecf8"
     ],
     [
       "FStar.Krml.Endianness.seq_uint32_of_be_be_of_seq_uint32",
@@ -2074,7 +2074,7 @@
         "typing_FStar.UInt8.t", "well-founded-ordering-on-nat"
       ],
       0,
-      "76d665a5544d5be41f971f84193db141"
+      "e946ed8034224a30370e57f8caf1742e"
     ],
     [
       "FStar.Krml.Endianness.be_of_seq_uint32_seq_uint32_of_be",
@@ -2086,7 +2086,7 @@
         "refinement_interpretation_Tm_refine_4239cb7a019da00e7afc3bc55aa05dd7"
       ],
       0,
-      "5308dc6b22d5d45dbee915af532e93a8"
+      "bf3b10d8609c746ebcc94c740b9b50b8"
     ],
     [
       "FStar.Krml.Endianness.be_of_seq_uint32_seq_uint32_of_be",
@@ -2164,7 +2164,7 @@
         "typing_FStar.UInt8.v", "well-founded-ordering-on-nat"
       ],
       0,
-      "c004ed2d6286023c2e9869959fd97252"
+      "bd95ffd98d813c586d85f78533e80779"
     ],
     [
       "FStar.Krml.Endianness.slice_seq_uint32_of_be",
@@ -2214,7 +2214,7 @@
         "typing_FStar.UInt32.t", "typing_FStar.UInt8.t"
       ],
       0,
-      "24a282113bf80b17420ebabb86522734"
+      "a61e1f258bfe8d24e178651fed5f2eae"
     ],
     [
       "FStar.Krml.Endianness.be_of_seq_uint32_slice",
@@ -2266,7 +2266,7 @@
         "typing_FStar.UInt8.t"
       ],
       0,
-      "1b2ac6edbbf1f1bd57771eb0e28514cd"
+      "dc3786bcd2b92b5af33807b71f03e55d"
     ]
   ]
 ]

--- a/krmllib/hints/LowStar.Lib.AssocList.fst.hints
+++ b/krmllib/hints/LowStar.Lib.AssocList.fst.hints
@@ -8,7 +8,7 @@
       0,
       [ "@query", "equation_LowStar.Lib.AssocList.invariant" ],
       0,
-      "9e9d8511cd8b61b98576ce6c4c603a7c"
+      "38b1454d11ef36870e772a10ce64e77a"
     ],
     [
       "LowStar.Lib.AssocList.frame",
@@ -73,7 +73,7 @@
         "typing_LowStar.Monotonic.Buffer.loc_union"
       ],
       0,
-      "be59ba82c68aa5e77968c1caf5956007"
+      "794f7f13d7e5a61ba5331f8ff5fa7913"
     ],
     [
       "LowStar.Lib.AssocList.footprint_in_r",
@@ -86,7 +86,7 @@
         "refinement_interpretation_Tm_refine_2de20c066034c13bf76e9c0b94f4806c"
       ],
       0,
-      "b39c9f31e5d397a1d2c14217a5798404"
+      "f79d5e9694527ea389c5a932e630503a"
     ],
     [
       "LowStar.Lib.AssocList.footprint_in_r",
@@ -102,7 +102,7 @@
         "fuel_guarded_inversion_LowStar.Lib.LinkedList2.t"
       ],
       0,
-      "46b8037732c20b742bf4655eaf4a58c1"
+      "e0c81d4c73f4aebca6b27e0a11c9654e"
     ],
     [
       "LowStar.Lib.AssocList.create_in",
@@ -136,7 +136,7 @@
         "typing_Tm_abs_05dbb0bdbe4a61cef8fed1432b1b98e9"
       ],
       0,
-      "23c51d824d5897f1cb2aa9b0b8c5d076"
+      "4838958741d8e26a052304a526908c15"
     ],
     [
       "LowStar.Lib.AssocList.find_",
@@ -145,7 +145,7 @@
       0,
       [ "@query" ],
       0,
-      "1a8e2fc39818165b3020b8b7d309461c"
+      "ca1d1e3552d82688dff60010590e108a"
     ],
     [
       "LowStar.Lib.AssocList.find_",
@@ -230,7 +230,7 @@
         "typing_Tm_abs_05dbb0bdbe4a61cef8fed1432b1b98e9"
       ],
       0,
-      "29e87e80c5fe0d59decd8ee3843bf716"
+      "df0a8254cc94496ae6564f1f3afac91c"
     ],
     [
       "LowStar.Lib.AssocList.find",
@@ -248,7 +248,7 @@
         "refinement_interpretation_Tm_refine_b582da5b18980dd549f83acfd27b47df"
       ],
       0,
-      "01ea86cbfa4758760fee4ce174386d9c"
+      "42964323ff4c18c02ea5c44f46b35b9a"
     ],
     [
       "LowStar.Lib.AssocList.add",
@@ -344,7 +344,7 @@
         "typing_Tm_abs_05dbb0bdbe4a61cef8fed1432b1b98e9"
       ],
       0,
-      "5b4812448de1f7d670ab5074ab974d82"
+      "b3c50f99cf06a4fa563f700aeaf4b2f0"
     ],
     [
       "LowStar.Lib.AssocList.remove_all_",
@@ -356,7 +356,7 @@
         "refinement_interpretation_Tm_refine_666cbc765faa85ecb6368ba0ccf434cd"
       ],
       0,
-      "52ec59aa8593e630a2e2f22285576389"
+      "476210cf6ca6084fb70952f9425a2d43"
     ],
     [
       "LowStar.Lib.AssocList.remove_all_",
@@ -485,7 +485,7 @@
         "typing_Tm_abs_05dbb0bdbe4a61cef8fed1432b1b98e9"
       ],
       0,
-      "4251637716c0b2113a13b52aa5f95109"
+      "caaa6ed0e14be88d18c875cd300bb583"
     ],
     [
       "LowStar.Lib.AssocList.remove_all",
@@ -597,7 +597,7 @@
         "typing_LowStar.Monotonic.Buffer.loc_regions"
       ],
       0,
-      "489d72cb883bc709be29f5e3efbd8c48"
+      "e295e50523c0dcac79472b9299fd80fe"
     ],
     [
       "LowStar.Lib.AssocList.clear",
@@ -756,7 +756,7 @@
         "typing_LowStar.Monotonic.Buffer.loc_union"
       ],
       0,
-      "7456a6f3dd392d32909eea4d09b91a64"
+      "b6f68387aec3587b68b7d69116b1887e"
     ]
   ]
 ]

--- a/krmllib/hints/LowStar.Lib.LinkedList.fst.hints
+++ b/krmllib/hints/LowStar.Lib.LinkedList.fst.hints
@@ -14,7 +14,7 @@
         "projection_inverse_BoxInt_proj_0", "subterm_ordering_Prims.Cons"
       ],
       0,
-      "ed4dd13273b8ad130b84a1510b885e0a"
+      "737a92646bfd9217d9634a32a94edc04"
     ],
     [
       "LowStar.Lib.LinkedList.cells",
@@ -50,7 +50,7 @@
         "typing_LowStar.Monotonic.Buffer.g_is_null"
       ],
       0,
-      "15d96e140625e8437360ad26c0f17fcc"
+      "af7784cdb081ab04285370eabaae22fd"
     ],
     [
       "LowStar.Lib.LinkedList.same_cells_same_pointer",
@@ -86,7 +86,7 @@
         "unit_typing"
       ],
       0,
-      "cf308d8c57725b6af199523f672a3b5e"
+      "16685815932f78f678ed12291fc4fcc5"
     ],
     [
       "LowStar.Lib.LinkedList.footprint",
@@ -118,7 +118,7 @@
         "subterm_ordering_Prims.Cons"
       ],
       0,
-      "848d7ea52c9a58bf2b8e32228d32ad77"
+      "f85fb6584c71b93e4d011527f48e43a7"
     ],
     [
       "LowStar.Lib.LinkedList.cells_pairwise_disjoint",
@@ -152,7 +152,7 @@
         "subterm_ordering_Prims.Cons"
       ],
       0,
-      "675c36f90b087439a0aaa00dc08dbd05"
+      "f1718f51f06f45f5ff69a579ab9cbed4"
     ],
     [
       "LowStar.Lib.LinkedList.cells_live_freeable",
@@ -186,7 +186,7 @@
         "subterm_ordering_Prims.Cons"
       ],
       0,
-      "b681793e7003cc1076b5bc439d15d284"
+      "37cf9e6ef3a660f27ea68dde43c61d63"
     ],
     [
       "LowStar.Lib.LinkedList.invariant",
@@ -195,7 +195,7 @@
       1,
       [ "@query", "equation_Prims.logical" ],
       0,
-      "dcc9cd0f28f00fa2873e81f589f8e390"
+      "06df0c2e1dc462e40b7f66cd3abb20b6"
     ],
     [
       "LowStar.Lib.LinkedList.invariant_loc_in_footprint",
@@ -209,7 +209,7 @@
         "refinement_interpretation_Tm_refine_2de20c066034c13bf76e9c0b94f4806c"
       ],
       0,
-      "8712a97d4da53bde37686669fdab32a2"
+      "0a5fb40db04413a7a22dfb8a751753c6"
     ],
     [
       "LowStar.Lib.LinkedList.invariant_loc_in_footprint",
@@ -273,7 +273,7 @@
         "typing_LowStar.Monotonic.Buffer.loc_not_unused_in"
       ],
       0,
-      "8d504e6f233e8b5f4e6f881fcf121d01"
+      "02679f6b323ce29342da1b80c520f195"
     ],
     [
       "LowStar.Lib.LinkedList.frame",
@@ -285,7 +285,7 @@
         "refinement_interpretation_Tm_refine_9dfd5ec664d04b1adbe6909975d3119f"
       ],
       0,
-      "d2942cedcbaafef6e3771f1ecc4f1bfa"
+      "4e05e050ef42d421776219cd65a2a8d7"
     ],
     [
       "LowStar.Lib.LinkedList.frame",
@@ -376,7 +376,7 @@
         "typing_LowStar.Monotonic.Buffer.loc_buffer"
       ],
       0,
-      "9f0b9f124427fb2e51c30bd96df10fea"
+      "7d48b90e887f4eb5d3dd4da4814e574b"
     ],
     [
       "LowStar.Lib.LinkedList.length_functional",
@@ -418,7 +418,7 @@
         "typing_LowStar.Buffer.trivial_preorder"
       ],
       0,
-      "67ceef9d6ae3adfeedce3c0038bece21"
+      "32e72eb020170608b04b99d5785f1982"
     ],
     [
       "LowStar.Lib.LinkedList.gmap",
@@ -433,7 +433,7 @@
         "projection_inverse_BoxBool_proj_0", "subterm_ordering_Prims.Cons"
       ],
       0,
-      "6f19715a84be251bf3058bb774d96ede"
+      "2bcfae0c104c0c6446748967d85ffb05"
     ],
     [
       "LowStar.Lib.LinkedList.gfold_right",
@@ -448,7 +448,7 @@
         "projection_inverse_BoxBool_proj_0", "subterm_ordering_Prims.Cons"
       ],
       0,
-      "cadd564f7b3501e7e6dec1db82f6316e"
+      "967b96ef13e913e1d225f9447328baf6"
     ],
     [
       "LowStar.Lib.LinkedList.deref_cells_is_v",
@@ -460,7 +460,7 @@
         "refinement_interpretation_Tm_refine_2cdb1d22d11cea5954bcab0f89d645ec"
       ],
       0,
-      "332252e50f6a446448a9611784c7507a"
+      "33263919686691932f87198462cb41f8"
     ],
     [
       "LowStar.Lib.LinkedList.deref_cells_is_v",
@@ -524,7 +524,7 @@
         "typing_LowStar.Lib.LinkedList.cells"
       ],
       0,
-      "c39349c9f4f3b993a742a4102826cab0"
+      "433be9ebb3400a6654970e620150dd05"
     ],
     [
       "LowStar.Lib.LinkedList.footprint_via_cells_is_footprint",
@@ -541,7 +541,7 @@
         "refinement_interpretation_Tm_refine_414d0a9f578ab0048252f8c8f552b99f"
       ],
       0,
-      "e58dc407c7bfc1e809ca3ce41140c763"
+      "740978b76453c9d053076d51ff4e8330"
     ],
     [
       "LowStar.Lib.LinkedList.footprint_via_cells_is_footprint",
@@ -629,7 +629,7 @@
         "typing_Tm_abs_3d46d953d7df849c026fcef6c4941216"
       ],
       0,
-      "2b4a9310ef44c73844a8d9ee0278723e"
+      "d2095ccf44b05348e4ba12be9333624b"
     ],
     [
       "LowStar.Lib.LinkedList.push",
@@ -641,7 +641,7 @@
         "refinement_interpretation_Tm_refine_2e3312cd41d7f5efbbbae3b2eeef697e"
       ],
       0,
-      "e4403ebfb0088a9007e126575071dc50"
+      "93bca97f34fae3291a4c6bed4a100319"
     ],
     [
       "LowStar.Lib.LinkedList.push",
@@ -773,7 +773,7 @@
         "typing_LowStar.Monotonic.Buffer.loc_unused_in"
       ],
       0,
-      "4d8449e4deb3d2f3dfe096a663bb806e"
+      "78c00aa5cbc526786403b0b7f1a595ff"
     ],
     [
       "LowStar.Lib.LinkedList.pop",
@@ -804,7 +804,7 @@
         "typing_LowStar.Buffer.trivial_preorder"
       ],
       0,
-      "b8e687d8b943bfa6f2626cafa8b54293"
+      "a9d13568f2fec810b58ff73139737417"
     ],
     [
       "LowStar.Lib.LinkedList.pop",
@@ -913,7 +913,7 @@
         "typing_LowStar.Monotonic.Buffer.loc_union"
       ],
       0,
-      "494c80ed3feb4550fb14c2dd88a18d03"
+      "1261bb1aee3bd59ec190db9e5eeae7ee"
     ],
     [
       "LowStar.Lib.LinkedList.free_",
@@ -925,7 +925,7 @@
         "refinement_interpretation_Tm_refine_994dd8cb51034b7a0776f9bb28ca6f71"
       ],
       0,
-      "608c6c847b3201e7382eb589b0fc7274"
+      "a99c67a2c7c80650ac3f0317b067a325"
     ],
     [
       "LowStar.Lib.LinkedList.free_",
@@ -1015,7 +1015,7 @@
         "typing_LowStar.Monotonic.Buffer.loc_buffer"
       ],
       0,
-      "eabef04476fe5463c2a315a21017e663"
+      "8dde157a06b34ec7df140eabd73b80f6"
     ],
     [
       "LowStar.Lib.LinkedList.free",
@@ -1027,7 +1027,7 @@
         "refinement_interpretation_Tm_refine_baa6a0434e5b51218cc000deadc8f6bc"
       ],
       0,
-      "bdb8e897a746d049afadbfdad82598ea"
+      "040c59025a8dfee4c7ee59b5d8466037"
     ],
     [
       "LowStar.Lib.LinkedList.free",
@@ -1114,7 +1114,7 @@
         "typing_LowStar.Monotonic.Buffer.mnull"
       ],
       0,
-      "b92c2b132227f2eb7a1ed13c4b62f9bd"
+      "f1141d1ef47fcae7da4cb70cb5b01d8b"
     ],
     [
       "LowStar.Lib.LinkedList.length",
@@ -1123,7 +1123,7 @@
       1,
       [ "@query" ],
       0,
-      "536f0678bcb8ad77fc78d00d4a12e6c1"
+      "ea22d5e7328df11b735c321663852749"
     ],
     [
       "LowStar.Lib.LinkedList.length",
@@ -1188,7 +1188,7 @@
         "typing_LowStar.Monotonic.Buffer.len"
       ],
       0,
-      "8e92a148382e00383e697e4b2e4c2bb7"
+      "aa54542dd4a168c0c84dd8e8fc402c94"
     ],
     [
       "LowStar.Lib.LinkedList.test",
@@ -1325,7 +1325,7 @@
         "typing_LowStar.Monotonic.Buffer.mnull"
       ],
       0,
-      "c32e450edb79291ffcb37bcd45ae031f"
+      "9ec4f6cfee4ec32bdc3e11dc614f0f12"
     ]
   ]
 ]

--- a/krmllib/hints/LowStar.Lib.LinkedList2.fst.hints
+++ b/krmllib/hints/LowStar.Lib.LinkedList2.fst.hints
@@ -17,7 +17,7 @@
         "typing_LowStar.Lib.LinkedList2.__proj__Mkt__item__r"
       ],
       0,
-      "a722aa88989d2e417e331ee6899781b0"
+      "f2721b2cb2b1efc51a304365f8a4c63f"
     ],
     [
       "LowStar.Lib.LinkedList2.footprint",
@@ -29,7 +29,7 @@
         "l_and-interp"
       ],
       0,
-      "95f5a1c8bf85c442599de3c7e5aec78a"
+      "61170fe6d25236523b4728721e790034"
     ],
     [
       "LowStar.Lib.LinkedList2.cells",
@@ -41,7 +41,7 @@
         "l_and-interp"
       ],
       0,
-      "f6a3418322784d12aa40e7145154d94b"
+      "e8044fd497c2060ef4c1ab01017f3ba1"
     ],
     [
       "LowStar.Lib.LinkedList2.footprint_in_r",
@@ -111,7 +111,7 @@
         "typing_LowStar.Monotonic.Buffer.loc_union"
       ],
       0,
-      "80c39e7e772b75892e53132de2af7f89"
+      "09b3e4274dff2cd68ee052dc1d5d3a59"
     ],
     [
       "LowStar.Lib.LinkedList2.frame_footprint",
@@ -123,7 +123,7 @@
         "refinement_interpretation_Tm_refine_09ad67b9d90ed7b17ddf31c45c68b636"
       ],
       0,
-      "9e9572193977263be908e683b1ac5be0"
+      "b05727b5b90536a9b087da42f0c15479"
     ],
     [
       "LowStar.Lib.LinkedList2.frame_footprint",
@@ -181,7 +181,7 @@
         "typing_LowStar.Monotonic.Buffer.loc_union"
       ],
       0,
-      "ee9a46266083e0a5bd201d2cdc18a241"
+      "6e1e3a2339298f57ac4f1d1138169d33"
     ],
     [
       "LowStar.Lib.LinkedList2.frame_region",
@@ -193,7 +193,7 @@
         "refinement_interpretation_Tm_refine_76a8d76aec5fe95490cf6c28517bab40"
       ],
       0,
-      "be2bd81839b2c6a71cca5f6dc4b688a9"
+      "758c475d889b85789cec6d18f356e89e"
     ],
     [
       "LowStar.Lib.LinkedList2.frame_region",
@@ -253,7 +253,7 @@
         "typing_LowStar.Monotonic.Buffer.loc_union"
       ],
       0,
-      "1a34f2b22d41fb7457c66459de2e25c7"
+      "7616d10b0b42c2c4f4850ab19a78664a"
     ],
     [
       "LowStar.Lib.LinkedList2.create_in",
@@ -262,7 +262,7 @@
       0,
       [ "@query" ],
       0,
-      "52b71ced237fd244b776921005391c2a"
+      "87c747cf985f0f8cd2e7ef88e685515c"
     ],
     [
       "LowStar.Lib.LinkedList2.create_in",
@@ -392,7 +392,7 @@
         "typing_LowStar.Monotonic.Buffer.mnull"
       ],
       0,
-      "443812b8c6703e3b7a79fd896503f735"
+      "e206ef287de48083410e696038a3696b"
     ],
     [
       "LowStar.Lib.LinkedList2.push",
@@ -404,7 +404,7 @@
         "refinement_interpretation_Tm_refine_89e26769e50512fd6a99e61c0fe00f0a"
       ],
       0,
-      "e0f7871e1bb8cc9eb18fc6a6ace5e81f"
+      "359271f504d64a69270f9fb5b3731d09"
     ],
     [
       "LowStar.Lib.LinkedList2.push",
@@ -521,7 +521,7 @@
         "typing_LowStar.Monotonic.Buffer.loc_union"
       ],
       0,
-      "3d394a89f32fc9148b40192f6782f518"
+      "c33da2f0e4c806e2c4f6269925a5dad1"
     ],
     [
       "LowStar.Lib.LinkedList2.pop",
@@ -567,7 +567,7 @@
         "typing_LowStar.Monotonic.Buffer.get"
       ],
       0,
-      "eb9ae880ac0adf567ce1c7187c9ab4c9"
+      "07e223bfea43787e5e265720ccc08ed3"
     ],
     [
       "LowStar.Lib.LinkedList2.pop",
@@ -689,7 +689,7 @@
         "typing_Prims.uu___is_Cons"
       ],
       0,
-      "5f0f6bed65a184e84dcb64018278e429"
+      "8c6ad0e20956be0dfb05a92676288ced"
     ],
     [
       "LowStar.Lib.LinkedList2.maybe_pop",
@@ -738,7 +738,7 @@
         "typing_LowStar.Monotonic.Buffer.get"
       ],
       0,
-      "c2312645c29c6485f1df31a8e0b04ef7"
+      "32a79d200bb950aa2b4199ef4056b547"
     ],
     [
       "LowStar.Lib.LinkedList2.maybe_pop",
@@ -883,7 +883,7 @@
         "typing_LowStar.Monotonic.Buffer.loc_union"
       ],
       0,
-      "2b9e5ac6853083f8654d1804c9366a61"
+      "df1fdf63017acc638b077465871dd5de"
     ],
     [
       "LowStar.Lib.LinkedList2.clear",
@@ -895,7 +895,7 @@
         "refinement_interpretation_Tm_refine_89e26769e50512fd6a99e61c0fe00f0a"
       ],
       0,
-      "4fa6e4fc9c489757dc025c3aae8e022b"
+      "afefca6aeaa3aa39e0fc1e776bb7eba4"
     ],
     [
       "LowStar.Lib.LinkedList2.clear",
@@ -1005,7 +1005,7 @@
         "typing_LowStar.Monotonic.Buffer.loc_union"
       ],
       0,
-      "f474240d76371cbaf4415a99598aad39"
+      "8e8bad8677b93e278cd1d495ddcf69b9"
     ],
     [
       "LowStar.Lib.LinkedList2.free",
@@ -1017,7 +1017,7 @@
         "refinement_interpretation_Tm_refine_89e26769e50512fd6a99e61c0fe00f0a"
       ],
       0,
-      "9d2783f6d10160d76a3d3dfcf12b1ae0"
+      "960db2be6bb28fb40b0cd1ed197d513a"
     ],
     [
       "LowStar.Lib.LinkedList2.free",
@@ -1096,7 +1096,7 @@
         "typing_LowStar.Monotonic.Buffer.loc_union"
       ],
       0,
-      "b1bb47ea438e0ed86a22a4cc6ee5235b"
+      "65440eb8017259ad98b40a5769442f5f"
     ],
     [
       "LowStar.Lib.LinkedList2.test",
@@ -1232,7 +1232,7 @@
         "typing_LowStar.Monotonic.Buffer.loc_unused_in"
       ],
       0,
-      "178a25c26adea1d914a5b29ddf0a4b5c"
+      "4e272f671e8c81f3902ceacf5375a3f2"
     ]
   ]
 ]

--- a/krmllib/hints/Spec.Loops.fst.hints
+++ b/krmllib/hints/Spec.Loops.fst.hints
@@ -13,7 +13,7 @@
         "refinement_interpretation_Tm_refine_414d0a9f578ab0048252f8c8f552b99f"
       ],
       0,
-      "7fe768d99e83e2403e6445a7e514812d"
+      "791401d459d165c655d17858a134cef0"
     ],
     [
       "Spec.Loops.seq_map",
@@ -27,7 +27,7 @@
         "refinement_interpretation_Tm_refine_414d0a9f578ab0048252f8c8f552b99f"
       ],
       0,
-      "e5f701d968251e069e31aa6a8dbaba52"
+      "9c9fd71790c77f696508e58af75336be"
     ],
     [
       "Spec.Loops.seq_map",
@@ -73,7 +73,7 @@
         "well-founded-ordering-on-nat"
       ],
       0,
-      "13d1fbf0347fe934b35f135813aab8e0"
+      "11eb809aad63c59d9d9470a911a4370e"
     ],
     [
       "Spec.Loops.seq_map2",
@@ -88,7 +88,7 @@
         "refinement_interpretation_Tm_refine_414d0a9f578ab0048252f8c8f552b99f"
       ],
       0,
-      "b99a8aa8eceaf04941ba3abfb352e122"
+      "173538a2c00fda3b05ff3f311d8d2175"
     ],
     [
       "Spec.Loops.seq_map2",
@@ -103,7 +103,7 @@
         "refinement_interpretation_Tm_refine_aab03343de950d77c26ad9d98d2757b8"
       ],
       0,
-      "91436226681b4d27521036ade087a87d"
+      "13bbb2a5a2d7faed0aa4536a7406413a"
     ],
     [
       "Spec.Loops.seq_map2",
@@ -152,7 +152,7 @@
         "well-founded-ordering-on-nat"
       ],
       0,
-      "2ed7a2943f3bdc32754f859220e35c48"
+      "f7d8d0380ea9d7e0f3f512d8a683a0cd"
     ],
     [
       "Spec.Loops.repeat",
@@ -169,7 +169,7 @@
         "well-founded-ordering-on-nat"
       ],
       0,
-      "f8a207ae629b674800390f9d2e872089"
+      "9474d0aedaa488c9e6f198a303bd14a4"
     ],
     [
       "Spec.Loops.repeat_induction",
@@ -182,7 +182,7 @@
         "refinement_interpretation_Tm_refine_afd51579b90d50ea23e03b743a1fa001"
       ],
       0,
-      "ad504c1dc1bd32be77ad128adde499e1"
+      "299819ec3b8cbec95a43f659af670f07"
     ],
     [
       "Spec.Loops.repeat_induction",
@@ -195,7 +195,7 @@
         "refinement_interpretation_Tm_refine_afd51579b90d50ea23e03b743a1fa001"
       ],
       0,
-      "e90274091ad3c5aa820aa1c06eda3098"
+      "b3aef938cbb55d29337dbb24fa671ec3"
     ],
     [
       "Spec.Loops.repeat_induction",
@@ -224,7 +224,7 @@
         "typing_Spec.Loops.repeat", "well-founded-ordering-on-nat"
       ],
       0,
-      "6dd34c60a5e35f99e932e2e887506b31"
+      "02b92bc4a0109848190a90cd26cf54b2"
     ],
     [
       "Spec.Loops.repeat_base",
@@ -247,7 +247,7 @@
         "refinement_interpretation_Tm_refine_f52d524f7d227b5c40129c018d34fe1d"
       ],
       0,
-      "bf9181f5f6297b26195b30b39aaa2a38"
+      "10246cbad11ca88df515e1c169be7757"
     ],
     [
       "Spec.Loops.repeat_range",
@@ -273,7 +273,7 @@
         "well-founded-ordering-on-nat"
       ],
       0,
-      "f4d39129ca67d8123c0bc3620cbe5d47"
+      "789110ee2ce42e4fe6bdc96ecbdf2ab8"
     ],
     [
       "Spec.Loops.repeat_range_base",
@@ -282,7 +282,7 @@
       1,
       [ "@query" ],
       0,
-      "c071f8855b74caae6afc01fcbe4036a6"
+      "265708bfc5d31da9d34ed04bb9f0d7eb"
     ],
     [
       "Spec.Loops.repeat_range_base",
@@ -299,7 +299,7 @@
         "refinement_interpretation_Tm_refine_571d9f74016be5357787170b42ecf913"
       ],
       0,
-      "a5af89c08250e55a5b9215785f09bd60"
+      "76bc4094b413510a8165a19baa5e3aaa"
     ],
     [
       "Spec.Loops.repeat_range_induction",
@@ -314,7 +314,7 @@
         "refinement_interpretation_Tm_refine_8233d76b57e95451540fc312b717fa79"
       ],
       0,
-      "a38b52e688f039266cec16ca4e5c07c4"
+      "85f354e357d051bd6fb3c541c3c5656e"
     ],
     [
       "Spec.Loops.repeat_range_induction",
@@ -329,7 +329,7 @@
         "refinement_interpretation_Tm_refine_8233d76b57e95451540fc312b717fa79"
       ],
       0,
-      "a840752290ba290cdc12b4c662216a88"
+      "8243c82c54167cb6e8458229866ad2ab"
     ],
     [
       "Spec.Loops.repeat_range_induction",
@@ -363,7 +363,7 @@
         "typing_Spec.Loops.repeat_range", "well-founded-ordering-on-nat"
       ],
       0,
-      "99c0b0d7a0e703c8e06a5a1e09e0bf76"
+      "bd4618c3d06ede6bbfbc85db4c456aba"
     ]
   ]
 ]

--- a/krmllib/hints/TestLib.fsti.hints
+++ b/krmllib/hints/TestLib.fsti.hints
@@ -8,7 +8,7 @@
       1,
       [ "@query" ],
       0,
-      "739c8c52de49921094671480f6d8ad93"
+      "7e748fd6d9c4489eff2f8eaad5032af4"
     ],
     [
       "TestLib.unsafe_malloc",
@@ -17,7 +17,7 @@
       1,
       [ "@query" ],
       0,
-      "f2fa89b45802ed075ffa14f11a87f3ca"
+      "ab769567c124003b6776a53eefdc668b"
     ]
   ]
 ]

--- a/krmllib/hints/WasmSupport.fst.hints
+++ b/krmllib/hints/WasmSupport.fst.hints
@@ -20,7 +20,7 @@
         "typing_FStar.Monotonic.HyperStack.get_hmap"
       ],
       0,
-      "a48c667c4c8d7cf1b57ab053e4e228b8"
+      "519fe3600db1ac154bb249a905e5f21e"
     ],
     [
       "WasmSupport.betole64",
@@ -29,7 +29,7 @@
       1,
       [ "@query" ],
       0,
-      "4923d6c80ecc355e3272d191ecfe6535"
+      "c77a461b7d7012eed9d5e6e853216711"
     ],
     [
       "WasmSupport.memzero",
@@ -63,7 +63,7 @@
         "typing_LowStar.Monotonic.Buffer.loc_buffer"
       ],
       0,
-      "a211ce8d4d29d7ff6413cba4c26956df"
+      "165dbd8e5d367e134432b2375b5b6ba1"
     ]
   ]
 ]

--- a/src/Ast.ml
+++ b/src/Ast.ml
@@ -208,6 +208,7 @@ type expr' =
     (** e1 (source), index; e2 (dest), index; len *)
   | EBufFill of expr * expr * expr
   | EBufFree of expr
+  | EBufNull
   | EPushFrame
   | EPopFrame
 

--- a/src/AstToCFlat.ml
+++ b/src/AstToCFlat.ml
@@ -547,7 +547,7 @@ let write_static (env: env) (lid: lident) (e: expr): string * CFlat.expr list =
          * dummy value. *)
         write_le dst ofs Helpers.uint32 (Z.of_int (Hashtbl.hash name'));
         [ CF.BufWrite (CF.GetGlobal name, ofs, CF.GetGlobal name', A32) ]
-    | EApp ({ node = EQualified (["LowStar"; "Monotonic"; "Buffer"], "mnull"); _ }, _) ->
+    | EBufNull ->
         write_le dst ofs Helpers.uint32 Z.zero;
         []
     | _ ->

--- a/src/AstToCFlat.ml
+++ b/src/AstToCFlat.ml
@@ -975,6 +975,9 @@ and mk_expr (env: env) (locals: locals) (e: expr): locals * CF.expr =
       let locals, e = mk_expr env locals e in
       locals, CF.Ignore (e, s)
 
+  | EBufNull ->
+      locals, CF.Constant (K.UInt32, "0")
+
 
 (* See digression for [dup32] in CFlatToWasm *)
 let scratch_locals =

--- a/src/AstToCFlat.ml
+++ b/src/AstToCFlat.ml
@@ -122,7 +122,8 @@ let width_of_poly_eq (env: env) (t: typ): K.width =
   match t with
   | TInt w ->
       w
-  | TBool | TUnit ->
+  | TBool | TUnit | TBuf _ ->
+      (* We can compare a pointer to NULL *)
       K.UInt32
   | TAnonymous (Enum _) ->
       K.UInt32

--- a/src/AstToCStar.ml
+++ b/src/AstToCStar.ml
@@ -275,6 +275,9 @@ let rec mk_expr env in_stmt e =
   | EAddrOf e ->
       CStar.AddrOf (mk_expr env e)
 
+  | EBufNull ->
+      CStar.BufNull
+
   | _ ->
       Warn.maybe_fatal_error (KPrint.bsprintf "%a" Loc.ploc env.location, NotLowStar e);
       CStar.Any

--- a/src/Builtin.ml
+++ b/src/Builtin.ml
@@ -200,12 +200,6 @@ let dyn: file =
       with_type void_star (ECast (with_type (TBound 0) (EBound 0), void_star)))
   ]
 
-let steel_reference : file =
-  "Steel_Reference", [
-    mk_val [ "Steel"; "Reference" ] "is_null" (TArrow (TBuf (TAny, false), TBool));
-    mk_val [ "Steel"; "Reference" ] "null" (TArrow (TAny, TBuf (TAny, false)));
-  ]
-
 let steel_sizet_intros : file =
   "Steel_ST_HigherArray", [
     mk_val ["Steel"; "ST"; "HigherArray" ] "intro_fits_u32" (TArrow (TUnit, TUnit));
@@ -214,8 +208,6 @@ let steel_sizet_intros : file =
 
 let lowstar_monotonic_buffer: file =
   "LowStar_Monotonic_Buffer", [
-    mk_val [ "LowStar"; "Monotonic"; "Buffer" ] "is_null" (TArrow (TBuf (TAny, false), TBool));
-    mk_val [ "LowStar"; "Monotonic"; "Buffer" ] "mnull" (TArrow (TAny, TBuf (TAny, false)));
     DFunction (None, [ Common.MustDisappear ], 3, TUnit,
       ([ "LowStar"; "Monotonic"; "Buffer" ], "recall"),
       [ fresh_binder "x" (TBuf (TBound 2, false)) ],
@@ -322,7 +314,6 @@ let hand_written = [
   lowstar_endianness;
   monotonic_hh;
   monotonic_hs;
-  steel_reference;
   steel_sizet_intros;
   hs;
   dyn;

--- a/src/CFlatToWasm.ml
+++ b/src/CFlatToWasm.ml
@@ -674,7 +674,7 @@ and mk_expr env (e: expr): W.Ast.instr list =
   | CallFunc ("LowStar_Monotonic_Buffer_mnull", [ _ ] )
   | CallFunc ("LowStar_Buffer_null", [ _ ] )
   | CallFunc ("C_Nullity_null", [ _ ]) ->
-      [ dummy_phrase (W.Ast.Const (mk_int32 0l)) ]
+      assert false
 
   | CallFunc (("load16_le_i" | "load16_le"), [ e ]) ->
       mk_expr env e @

--- a/src/CStar.ml
+++ b/src/CStar.ml
@@ -61,6 +61,7 @@ and expr =
      * on the rhs of a (typed) assignment *)
   | BufRead of expr * expr
   | BufSub of expr * expr
+  | BufNull
   | Op of K.op
   | Cast of expr * typ
     (** to *)

--- a/src/CStarToC11.ml
+++ b/src/CStarToC11.ml
@@ -273,6 +273,7 @@ let rec vars_of m = function
   | StringLiteral _
   | Any
   | EAbort _
+  | BufNull
   | Op _ ->
       S.empty
   | Cast (e, _)
@@ -1058,21 +1059,13 @@ and mk_expr m (e: expr): C.expr =
   | BufRead (e1, e2) ->
       mk_index m e1 e2
 
-  | Call (Qualified ([ "LowStar"; "Monotonic"; "Buffer" ], "mnull"), _)
-  | Call (Qualified ([ "LowStar"; "Buffer" ], "null"), _)
-  | Call (Qualified ([ "Steel"; "Reference" ], "null"), _)
-  | Call (Qualified ([ "C"; "Nullity" ], "null"), _) ->
+  | BufNull ->
       Name "NULL"
 
   | Call (Qualified ( [ "Steel"; "ST"; "HigherArray" ], "intro_fits_u32"), _ ) ->
       Call (Name "static_assert", [Op2 (K.Lte, Name "UINT32_MAX", Name "SIZE_MAX")])
   | Call (Qualified ( [ "Steel"; "ST"; "HigherArray" ], "intro_fits_u64"), _ ) ->
       Call (Name "static_assert", [Op2 (K.Lte, Name "UINT64_MAX", Name "SIZE_MAX")])
-
-  | Call (Qualified ( [ "LowStar"; "Monotonic"; "Buffer" ], "is_null"), [ e ] )
-  | Call (Qualified ( [ "Steel"; "Reference" ], "is_null"), [ e ] )
-  | Call (Qualified ( [ "C"; "Nullity" ], "is_null"), [ e ]) ->
-      Op2 (K.Eq, mk_expr m e, C.Name "NULL")
 
   | Call (Qualified ( [ "FStar"; "UInt128" ], "add"), [ e1; e2 ]) when !Options.builtin_uint128 ->
       Op2 (K.Add, mk_expr m e1, mk_expr m e2)

--- a/src/Checker.ml
+++ b/src/Checker.ml
@@ -290,6 +290,7 @@ and check' env t e =
   | EOp _
   | EPushFrame | EPopFrame
   | EAny | EAbort _
+  | EBufNull
   | EReturn _
   | EBreak
   | EBool _
@@ -755,6 +756,11 @@ and infer' env e =
 
   | EAddrOf e ->
       TBuf (infer env e, false)
+
+  | EBufNull ->
+      assert (e.typ <> TAny);
+      (* e.typ is the type of the whole node, so it's already of the form TBuf _ *)
+      e.typ
 
 and infer_and_check_eq: 'a. env -> ('a -> typ) -> 'a list -> typ =
   fun env f l ->

--- a/src/Helpers.ml
+++ b/src/Helpers.ml
@@ -178,15 +178,8 @@ let is_array = function TArray _ -> true | _ -> false
 let is_union = function TAnonymous (Union _) -> true | _ -> false
 
 let is_null = function
-  | { node = EApp (
-      { node = EQualified (
-          ([ "LowStar"; "Buffer" ] | [ "Steel"; "Reference" ] | [ "C"; "Nullity" ]), "null" |
-          ([ "LowStar"; "Monotonic"; "Buffer" ], "mnull"));
-        _ }, _); _ }
-  ->
-      true
-  | _ ->
-      false
+  | { node = EBufNull; _ } -> true
+  | _ -> false
 
 let is_uu name = KString.starts_with name "uu__"
 

--- a/src/Helpers.ml
+++ b/src/Helpers.ml
@@ -243,8 +243,6 @@ let is_readonly_builtin_lid lid =
     [ "FStar"; "UInt32" ], "v";
     [ "FStar"; "UInt128" ], "uint128_to_uint64";
     [ "FStar"; "UInt128" ], "uint64_to_uint128";
-    [ "LowStar"; "Monotonic"; "Buffer" ], "mnull";
-    [ "Steel"; "Reference" ], "null";
   ] in
   List.exists (fun lid' ->
     let lid = Idents.string_of_lident lid in

--- a/src/InputAst.ml
+++ b/src/InputAst.ml
@@ -103,6 +103,7 @@ and expr =
   | EComment of (string * expr * string)
   | EStandaloneComment of string
   | EAddrOf of expr
+  | EBufNull of typ
 
 and branches =
   branch list

--- a/src/InputAstToAst.ml
+++ b/src/InputAstToAst.ml
@@ -139,6 +139,21 @@ and mk_expr = function
       mk (EUnit)
   | I.EString s ->
       mk (EString s)
+
+  | I.EApp (I.ETApp (I.EQualified ([ "LowStar"; "Monotonic"; "Buffer" ], "mnull"), [ t; _; _ ]), [ I.EUnit ])
+  | I.EApp (I.ETApp (I.EQualified ([ "LowStar"; "Buffer" ], "null"), [ t ]), [ I.EUnit ])
+  | I.EApp (I.ETApp (I.EQualified ([ "LowStar"; "ConstBuffer" ], "null"), [ t ]), [ I.EUnit ])
+  | I.EApp (I.ETApp (I.EQualified ([ "Steel"; "Reference" ], "null"), [ t ]), [ I.EUnit ])
+  | I.EApp (I.ETApp (I.EQualified ([ "C"; "Nullity" ], "null"), [ t ]), [ I.EUnit ])
+  | I.EBufNull t ->
+      { node = EBufNull; typ = TBuf (mk_typ t, false) }
+
+  | I.EApp (I.ETApp (I.EQualified ( [ "LowStar"; "Monotonic"; "Buffer" ], "is_null"), [ t; _; _ ]), [ e ])
+  | I.EApp (I.ETApp (I.EQualified ( [ "Steel"; "Reference" ], "is_null"), [ t ]), [ e ]) ->
+      mk (EApp (mk (EPolyComp (K.PEq, TBuf (mk_typ t, false))), [
+        mk_expr e;
+        { node = EBufNull; typ = TBuf (mk_typ t, false) }]))
+
   | I.EApp (e, es) ->
       mk (EApp (mk_expr e, List.map mk_expr es))
   | I.ETApp (I.EOp ((K.Eq | K.Neq as op), _), [ t ]) ->

--- a/src/PrintAst.ml
+++ b/src/PrintAst.ml
@@ -298,6 +298,8 @@ and print_expr { node; typ } =
       ampersand ^^ parens_with_nesting (print_expr e)
   | EPolyComp (c, t) ->
       parens_with_nesting (print_poly_comp c ^^ comma ^^ space ^^ print_typ t)
+  | EBufNull ->
+      string "NULL" ^^ langle ^^ print_typ typ ^^ rangle
 
 and print_poly_comp = function
   | PEq -> equals

--- a/src/Simplify.ml
+++ b/src/Simplify.ml
@@ -875,6 +875,7 @@ and hoist_expr loc pos e =
   | ETApp _ ->
       assert false
 
+  | EBufNull
   | EAbort _
   | EAny
   | EBound _

--- a/src/SimplifyMerge.ml
+++ b/src/SimplifyMerge.ml
@@ -75,7 +75,8 @@ let rec merge' (env: env) (u: S.t) (e: expr): S.t * S.t * expr =
   | EPopFrame
   | EEnum _
   | EStandaloneComment _
-  | EAbort _ ->
+  | EAbort _
+  | EBufNull ->
       keys env, u, e
 
   | EOpen (_, a) ->

--- a/src/Structs.ml
+++ b/src/Structs.ml
@@ -527,6 +527,9 @@ let to_addr is_struct =
         (* Not descending, this is already an address *)
         w (EBufFree e)
 
+    | EBufNull ->
+        w EBufNull
+
     | ESwitch (e, branches) ->
         let e = to_addr false e in
         let branches = List.map (fun (lid, e) -> lid, to_addr false e) branches in


### PR DESCRIPTION
A node `BufNull t` has type `t*`.

Backwards-compat desugaring of old application nodes in InputAst.ml