### PR TITLE
Do not include callconv.h by default anymore

### DIFF
--- a/include/krml/internal/callconv.h
+++ b/include/krml/internal/callconv.h
@@ -5,7 +5,7 @@
 #define __KRML_CALLCONV_H
 
 /******************************************************************************/
-/* Some macros to ease compatibility                                          */
+/* Some macros to ease compatibility (TODO: move to miTLS)                    */
 /******************************************************************************/
 
 /* We want to generate __cdecl safely without worrying about it being undefined.
@@ -24,23 +24,3 @@
 #endif
 #endif
 
-/* Since KaRaMeL emits the inline keyword unconditionally, we follow the
- * guidelines at https://gcc.gnu.org/onlinedocs/gcc/Inline.html and make this
- * __inline__ to ensure the code compiles with -std=c90 and earlier. */
-#ifdef __GNUC__
-#  define inline __inline__
-#endif
-
-/* GCC-specific attribute syntax; everyone else gets the standard C inline
- * attribute. */
-#ifdef __GNU_C__
-#  ifndef __clang__
-#    define force_inline inline __attribute__((always_inline))
-#  else
-#    define force_inline inline
-#  endif
-#else
-#  define force_inline inline
-#endif
-
-#endif

--- a/include/krml/internal/callconv.h
+++ b/include/krml/internal/callconv.h
@@ -24,3 +24,4 @@
 #endif
 #endif
 
+#endif

--- a/include/krml/internal/target.h
+++ b/include/krml/internal/target.h
@@ -12,7 +12,12 @@
 #include <limits.h>
 #include <assert.h>
 
-#include "krml/internal/callconv.h"
+/* Since KaRaMeL emits the inline keyword unconditionally, we follow the
+ * guidelines at https://gcc.gnu.org/onlinedocs/gcc/Inline.html and make this
+ * __inline__ to ensure the code compiles with -std=c90 and earlier. */
+#ifdef __GNUC__
+#  define inline __inline__
+#endif
 
 /******************************************************************************/
 /* Macros that KaRaMeL will generate.                                         */


### PR DESCRIPTION
This was used chiefly for miTLS. There's one detail about inline and antediluvian gcc versions that moved to target.h

The header will linger around (I have a patch to exclude it from dist/karamel in HACL* forthcoming) until it is removed for good.