### PR TITLE
New input AST node: EIsNull

### DIFF
--- a/src/InputAst.ml
+++ b/src/InputAst.ml
@@ -104,6 +104,7 @@ and expr =
   | EStandaloneComment of string
   | EAddrOf of expr
   | EBufNull of typ
+  | EIsNull of (typ * expr)
 
 and branches =
   branch list

--- a/src/InputAstToAst.ml
+++ b/src/InputAstToAst.ml
@@ -148,6 +148,7 @@ and mk_expr = function
   | I.EBufNull t ->
       { node = EBufNull; typ = TBuf (mk_typ t, false) }
 
+  | I.EIsNull (t, e)
   | I.EApp (I.ETApp (I.EQualified ( [ "LowStar"; "Monotonic"; "Buffer" ], "is_null"), [ t; _; _ ]), [ e ])
   | I.EApp (I.ETApp (I.EQualified ( [ "Steel"; "Reference" ], "is_null"), [ t ]), [ e ]) ->
       mk (EApp (mk (EPolyComp (K.PEq, TBuf (mk_typ t, false))), [


### PR DESCRIPTION
#318 introduced a new node for null buffers, `EBufNull`. However, nothing was provided in the input AST (as opposed to the AST) to compare a pointer to NULL: polymorphic comparisons seem to be impossible in the input AST.
Thus, this PR introduces a new node for comparing a pointer to null, `EIsNull`.
