### PR TITLE
Primitive extraction of within_bounds

### DIFF
--- a/include/krml/internal/builtin.h
+++ b/include/krml/internal/builtin.h
@@ -13,7 +13,7 @@
  * generate and try to link last a function with this type: */
 void krmlinit_globals(void);
 
-static inline within_bounds_intro(void *left, void *p, void *right) {
+static inline bool within_bounds_intro(void *left, void *p, void *right) {
   return (uintptr_t) left <= (uintptr_t) p && (uintptr_t) p <= (uintptr_t) right;
 }
 

--- a/include/krml/internal/builtin.h
+++ b/include/krml/internal/builtin.h
@@ -13,8 +13,4 @@
  * generate and try to link last a function with this type: */
 void krmlinit_globals(void);
 
-static inline bool within_bounds_ptr(void *left, void *p, void *right) {
-  return (uintptr_t) left <= (uintptr_t) p && (uintptr_t) p <= (uintptr_t) right;
-}
-
 #endif

--- a/include/krml/internal/builtin.h
+++ b/include/krml/internal/builtin.h
@@ -13,7 +13,7 @@
  * generate and try to link last a function with this type: */
 void krmlinit_globals(void);
 
-static inline bool within_bounds_intro(void *left, void *p, void *right) {
+static inline bool within_bounds_ptr(void *left, void *p, void *right) {
   return (uintptr_t) left <= (uintptr_t) p && (uintptr_t) p <= (uintptr_t) right;
 }
 

--- a/include/krml/internal/builtin.h
+++ b/include/krml/internal/builtin.h
@@ -13,4 +13,8 @@
  * generate and try to link last a function with this type: */
 void krmlinit_globals(void);
 
+static inline within_bounds_intro(void *left, void *p, void *right) {
+  return (uintptr_t) left <= (uintptr_t) p && (uintptr_t) p <= (uintptr_t) right;
+}
+
 #endif

--- a/include/krml/steel_base.h
+++ b/include/krml/steel_base.h
@@ -1,0 +1,11 @@
+/* Copyright (c) INRIA and Microsoft Corporation. All rights reserved.
+   Licensed under the Apache 2.0 License. */
+
+#ifndef __KRML_STEEL_BASE_H
+#define __KRML_STEEL_BASE_H
+
+static inline bool within_bounds_ptr(void *left, void *p, void *right) {
+  return (uintptr_t) left <= (uintptr_t) p && (uintptr_t) p <= (uintptr_t) right;
+}
+
+#endif

--- a/include/krmllib.h
+++ b/include/krmllib.h
@@ -24,5 +24,6 @@
 
 #include "krml/lowstar_endianness.h"
 #include "krml/fstar_int.h"
+#include "krml/steel_base.h"
 
 #endif     /* __KRMLLIB_H */

--- a/src/Builtin.ml
+++ b/src/Builtin.ml
@@ -206,6 +206,20 @@ let steel_sizet_intros : file =
     mk_val ["Steel"; "ST"; "HigherArray" ] "intro_fits_u64" (TArrow (TUnit, TUnit));
   ]
 
+let steel_arrayarith : file =
+  "Steel_ArrayArith", [
+    mk_val ["Steel"; "ArrayArith"] "within_bounds_ptr"
+      (TArrow 
+        (* The three arrays passed as arguments *)
+        (TBuf (TAny, false), TArrow (TBuf (TAny, false), TArrow (TBuf (TAny, false), 
+        (* The three ghost lengths, extracted to unit *)
+        TArrow (TUnit, TArrow (TUnit, TArrow (TUnit,
+        (* The three ghost sequences, extracted to unit *)
+        TArrow (TUnit, TArrow (TUnit, TArrow (TUnit,
+        (* The actual return type *)
+        TBool))))))))))
+  ]
+
 let lowstar_monotonic_buffer: file =
   "LowStar_Monotonic_Buffer", [
     DFunction (None, [ Common.MustDisappear ], 3, TUnit,
@@ -314,6 +328,7 @@ let hand_written = [
   lowstar_endianness;
   monotonic_hh;
   monotonic_hs;
+  steel_arrayarith;
   steel_sizet_intros;
   hs;
   dyn;
@@ -384,7 +399,6 @@ let is_model name =
       "C_String";
       "C_Compat_String";
       "FStar_String";
-      "Steel_ArrayArith";
       "Steel_SpinLock"
     ]
 

--- a/src/Builtin.ml
+++ b/src/Builtin.ml
@@ -384,6 +384,7 @@ let is_model name =
       "C_String";
       "C_Compat_String";
       "FStar_String";
+      "Steel_ArrayArith";
       "Steel_SpinLock"
     ]
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -159,6 +159,7 @@ $(OUTPUT_DIR)/MonomorphizationCrash.exe: EXTRA=monomorphization_crash.c -add-inc
 $(OUTPUT_DIR)/MonomorphizationSeparate2.exe: EXTRA=-bundle MonomorphizationSeparate1=
 $(OUTPUT_DIR)/Loops.exe: EXTRA=-funroll-loops 16
 $(OUTPUT_DIR)/GlobalInit.exe: EXTRA=global_init.c
+$(OUTPUT_DIR)/SteelArrayArith.exe: EXTRA=-static-header Steel.ArrayArith -no-prefix Steel.ArrayArith
 $(OUTPUT_DIR)/SteelLock.exe: EXTRA=-bundle Steel.* -add-include 'Steel:"krml/steel_types.h"'
 $(OUTPUT_DIR)/SizeT.exe: EXTRA=-ccopt -std=c2x
 

--- a/test/SteelArrayArith.fst
+++ b/test/SteelArrayArith.fst
@@ -1,0 +1,26 @@
+module SteelArrayArith
+
+open Steel.Effect.Atomic
+open Steel.Effect
+open Steel.Array
+open Steel.ArrayArith
+
+let main () : SteelT Int32.t emp (fun _ -> emp) =
+  let r = malloc 0ul 3sz in
+  ghost_split r 1sz;
+  let r1 = split_r r 1sz in
+  change_equal_slprop (varray (split_r r 1sz)) (varray r1);
+  ghost_split r1 1sz;
+  let r2 = split_r r1 1sz in
+  change_equal_slprop (varray (split_r r1 1sz)) (varray r2);
+  let b = within_bounds_intro (split_l r 1sz) (split_l r1 1sz) r2 in
+  ghost_join (split_l r1 1sz) r2 ();
+  change_equal_slprop
+    (varray (merge (split_l r1 1sz) r2))
+    (varray r1);
+  ghost_join (split_l r 1sz) r1 ();
+  change_equal_slprop
+    (varray (merge (split_l r 1sz) r1))
+    (varray r);
+  free r;
+  if b then 0l else 1l


### PR DESCRIPTION
This PR is the companion PR of https://github.com/FStarLang/FStar/pull/2799, which adds a new primitive for restricted pointer comparison.

Most of the documentation is in the corresponding F* module, from karamel's perspective, this PR:
* Adds Steel.ArrayArith.within_bounds_ptr as a primitive builtin, with the signature (post-erasure) that it has in Steel.
* Adds a handwritten implementation of within_bounds_ptr, that is added to builtins.h. This implementation first casts the pointers to uintptr_t, as operations on pointers from different allocation units are undefined according to the C standard (section 6.5.8). Note, I added this function to builtins.h instead of steel_types.h to avoid bringing pthread in the context when concurrency is not required, but there might be a better place for this primitive.
* Adds a test demonstrating how to use and extract this primitive. Passing the options -static_header Steel.ArrayArith -no-prefix Steel.ArrayArith is required for linking to succeed.