### PR TITLE
Positivity escape hatches for test cases

### DIFF
--- a/test/DataTypesMut.fst
+++ b/test/DataTypesMut.fst
@@ -2,12 +2,14 @@ module DataTypesMut
 
 module B = FStar.Buffer
 
+#push-options "--__no_positivity"
 noeq
 type t1 a = a * a
 and t2 a =
   | T2 of B.buffer (t3 a) * B.buffer (t3 Int32.t)
 and t3 a =
   | T3 of a * t1 Int64.t * B.buffer (t2 a) * B.buffer (t2 Int16.t)
+#pop-options
 
 (* The dependency graph is as follows:
 

--- a/test/ForwardDecl.fst
+++ b/test/ForwardDecl.fst
@@ -2,10 +2,12 @@ module ForwardDecl
 
 module B = LowStar.Buffer
 
+#push-options "--__no_positivity"
 unopteq type a = {
  x : b;
 } and b = {
  y : B.pointer a;
 }
+#pop-options
 
 let main () = 0l

--- a/test/Wireguard.fst
+++ b/test/Wireguard.fst
@@ -40,6 +40,7 @@ let rec gfind2 #a #b #c (f: a -> b -> GTot (option c)) (xs: list a) (ys: list b)
 // wireguard, alas.
 let handshake_state = B.buffer UInt8.t
 
+#push-options "--__no_positivity"
 noeq
 // Simplified equivalent of wg_peer.
 type peer = {
@@ -62,6 +63,7 @@ and device = {
   // Region for the payload of each list cell.
   r_peers_payload: HS.rid;
 }
+#pop-options
 
 // Naming a bunch of abbreviations for code-gen quality
 let peer_list2 = LL2.t peer


### PR DESCRIPTION
This F* PR fixes a bug in the positivity checker that was not handling mutually inductive types correctly.
https://github.com/FStarLang/FStar/pull/2811

So, a few karamel test cases need no-positivity pragmas.

It seems that one of the examples is meant to be a minimalistic version of WireGuard? It's likely then that the actual F* sources of that application also needs this pragma ... at least until the Low* buffer type gains a positivity attribute.