### PR TITLE
Update within_bounds builtin with permissions

### DIFF
--- a/src/Builtin.ml
+++ b/src/Builtin.ml
@@ -210,14 +210,16 @@ let steel_arrayarith : file =
   "Steel_ArrayArith", [
     mk_val ["Steel"; "ArrayArith"] "within_bounds_ptr"
       (TArrow 
+        (* The three permissions, extracted to unit *)
+        (TUnit, TArrow (TUnit, TArrow (TUnit,
         (* The three arrays passed as arguments *)
-        (TBuf (TAny, false), TArrow (TBuf (TAny, false), TArrow (TBuf (TAny, false), 
+        TArrow (TBuf (TAny, false), TArrow (TBuf (TAny, false), TArrow (TBuf (TAny, false), 
         (* The three ghost lengths, extracted to unit *)
         TArrow (TUnit, TArrow (TUnit, TArrow (TUnit,
         (* The three ghost sequences, extracted to unit *)
         TArrow (TUnit, TArrow (TUnit, TArrow (TUnit,
         (* The actual return type *)
-        TBool))))))))))
+        TBool)))))))))))))
   ]
 
 let lowstar_monotonic_buffer: file =


### PR DESCRIPTION
This PR is the companion PR of https://github.com/FStarLang/FStar/pull/2834
It extends support added in #325 for primitive extraction of Steel.ArrayArith.within_bounds, to add permissions to the primitive.