### PR TITLE
Adds native extraction of intro_fits_ptrdiff{32,64}

### DIFF
--- a/src/Builtin.ml
+++ b/src/Builtin.ml
@@ -204,6 +204,8 @@ let steel_sizet_intros : file =
   "Steel_ST_HigherArray", [
     mk_val ["Steel"; "ST"; "HigherArray" ] "intro_fits_u32" (TArrow (TUnit, TUnit));
     mk_val ["Steel"; "ST"; "HigherArray" ] "intro_fits_u64" (TArrow (TUnit, TUnit));
+    mk_val ["Steel"; "ST"; "HigherArray" ] "intro_fits_ptrdiff32" (TArrow (TUnit, TUnit));
+    mk_val ["Steel"; "ST"; "HigherArray" ] "intro_fits_ptrdiff64" (TArrow (TUnit, TUnit));
   ]
 
 let steel_arrayarith : file =

--- a/src/CStarToC11.ml
+++ b/src/CStarToC11.ml
@@ -24,6 +24,8 @@ let builtin_names =
     ["Steel"; "Reference"], "is_null";
     ["Steel"; "ST"; "HigherArray"], "intro_fits_u32";
     ["Steel"; "ST"; "HigherArray"], "intro_fits_u64";
+    ["Steel"; "ST"; "HigherArray"], "intro_fits_ptrdiff32";
+    ["Steel"; "ST"; "HigherArray"], "intro_fits_ptrdiff64";
     ["C"; "Nullity"], "null";
     ["C"; "String"], "get";
     ["C"; "String"], "t";
@@ -1074,6 +1076,10 @@ and mk_expr m (e: expr): C.expr =
       Call (Name "static_assert", [Op2 (K.Lte, Name "UINT32_MAX", Name "SIZE_MAX")])
   | Call (Qualified ( [ "Steel"; "ST"; "HigherArray" ], "intro_fits_u64"), _ ) ->
       Call (Name "static_assert", [Op2 (K.Lte, Name "UINT64_MAX", Name "SIZE_MAX")])
+  | Call (Qualified ( [ "Steel"; "ST"; "HigherArray" ], "intro_fits_ptrdiff32"), _ ) ->
+      Call (Name "static_assert", [Op2 (K.Lte, Name "INT32_MAX", Name "PTRDIFF_MAX")])
+  | Call (Qualified ( [ "Steel"; "ST"; "HigherArray" ], "intro_fits_ptrdiff64"), _ ) ->
+      Call (Name "static_assert", [Op2 (K.Lte, Name "INT64_MAX", Name "PTRDIFF_MAX")])
 
   | Call (Qualified ( [ "FStar"; "UInt128" ], "add"), [ e1; e2 ]) when !Options.builtin_uint128 ->
       Op2 (K.Add, mk_expr m e1, mk_expr m e2)

--- a/test/SizeT.fst
+++ b/test/SizeT.fst
@@ -28,6 +28,7 @@ open Steel.Array
 let main () : SteelT Int32.t emp (fun _ -> emp) =
   let x = f () in
   let _:squash (fits_u32) = intro_fits_u32 () in
+  let _ = intro_fits_ptrdiff32 () in
   let y = of_u32 500000ul in
   let r = 4000ul in
   let r = uint32_to_sizet r in


### PR DESCRIPTION
Companion PR of https://github.com/FStarLang/FStar/pull/2837.
Adds native extraction of intro_fits_ptrdiff{32,64}, similarly to what is currently done for size_t.