### PR TITLE
add Nix support

### DIFF
--- a/.nix/karamel.nix
+++ b/.nix/karamel.nix
@@ -1,0 +1,54 @@
+{ fstar, ocamlPackages, removeReferencesTo, stdenv, symlinks, version, which, z3
+}:
+
+stdenv.mkDerivation {
+  pname = "karamel";
+  inherit version;
+
+  src = ./..;
+
+  outputs = [ "out" "home" ];
+
+  buildInputs = [ fstar removeReferencesTo symlinks which z3 ]
+    ++ (with ocamlPackages; [
+      ocaml
+      ocamlbuild
+      findlib
+      batteries
+      stdint
+      ppx_deriving_yojson
+      zarith
+      pprint
+      menhir
+      menhirLib
+      sedlex
+      process
+      fix
+      wasm
+      visitors
+      ctypes
+    ]);
+
+  FSTAR_HOME = fstar;
+
+  configurePhase = "export KRML_HOME=$(pwd)";
+
+  enableParallelBuilding = true;
+
+  preBuild = "mkdir -p krmllib/hints";
+
+  preInstall = "export PREFIX=$out";
+  postInstall = ''
+    # OCaml leaves its full store path in produced binaries
+    # Thus we remove every reference to it
+    for binary in $out/bin/*
+    do
+      remove-references-to -t '${ocamlPackages.ocaml}' $binary
+    done
+
+    symlinks -c $KRML_HOME
+    cp -r ./. $home
+  '';
+
+  dontFixup = true;
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,23 @@
+{
+  inputs = {
+    fstar.url = "github:fstarlang/fstar";
+    flake-utils.follows = "fstar/flake-utils";
+    nixpkgs.follows = "fstar/nixpkgs";
+  };
+
+  outputs = { self, fstar, flake-utils, nixpkgs }:
+    flake-utils.lib.eachSystem [ "x86_64-linux" ] (system:
+      let
+        fstarPackages = fstar.packages.${system};
+        pkgs = import nixpkgs { inherit system; };
+        karamel = pkgs.callPackage ./.nix/karamel.nix {
+          inherit (fstarPackages) fstar ocamlPackages z3;
+          version = self.rev or "dirty";
+        };
+      in {
+        packages = {
+          inherit karamel;
+          default = karamel;
+        };
+      });
+}


### PR DESCRIPTION
This PR adds a Nix expression to build Karamel.
It does not interfere with the current build process.
Currently the expression is part of the hacl-star repository,
moving it here would make it more visible to interested users and easier to maintain.