### PR TITLE
Relax dubious heuristic

### DIFF
--- a/src/CFlatToWasm.ml
+++ b/src/CFlatToWasm.ml
@@ -908,7 +908,7 @@ and mk_expr env (e: expr): W.Ast.instr list =
   | Switch (e, branches, default, s) ->
       let vmax = KList.max (List.map (fun (c, _) -> Z.of_string (snd c)) branches) in
       let vmin = KList.min (List.map (fun (c, _) -> Z.of_string (snd c)) branches) in
-      if Z.( gt vmax ~$10 || lt vmin ~$0 ) then
+      if Z.( gt vmax ~$20 || lt vmin ~$0 ) then
         failwith "TODO: in AstToCFlat, don't pick Switch for matches on integers!";
 
       (*


### PR DESCRIPTION
The intent seems to be avoiding non-contiguous jump tables. But with so many cases in Spec.Hash.Definitions.hash_alg, we definitely do build a contiguous jump table with more than ten entries. See https://github.com/hacl-star/hacl-star/pull/800