### PR TITLE
Fix Nix build

### DIFF
--- a/.nix/karamel.nix
+++ b/.nix/karamel.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation {
   buildInputs = [ fstar removeReferencesTo symlinks which z3 ]
     ++ (with ocamlPackages; [
       ocaml
-      ocamlbuild
+      dune_3
       findlib
       batteries
       stdint


### PR DESCRIPTION
Fix Nix build after changing the build system from `ocamlbuild` to `dune` in #212.