### PR TITLE
install-other-deps.sh: stricter regex to only remove fstar dependency

### DIFF
--- a/.docker/build/install-other-deps.sh
+++ b/.docker/build/install-other-deps.sh
@@ -6,5 +6,5 @@ set -x
 build_home="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd "$build_home/../.."
 
-grep -v -i fstar < karamel.opam > karamel-nofstar.opam
+grep -v '"fstar"' < karamel.opam > karamel-nofstar.opam
 opam install --deps-only ./karamel-nofstar.opam

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ fstar-mode.el
 .#*
 src/Version.ml
 *.runlim
+karamel-nofstar.opam


### PR DESCRIPTION
Otherwise this removes many more lines, causing some warnings. Abridged diff:

```diff
 authors: "Jonathan Protzenko <jonathan.protzenko@gmail.com>"
-homepage: "https://github.com/fstarlang/karamel"
 license: "Apache-2.0"
 depends: [
 "ocaml" {>= "4.10.0"}
-  "fstar"
 ]
-dev-repo: "git+https://github.com/FStarLang/karamel"
-bug-reports: "https://github.com/FStarLang/karamel/issues" 
 url {
-  src: "https://github.com/FStarLang/karamel/archive/refs/tags/v1.0.0.zip"
```

The warnings in F* CI:

	opam install --deps-only ./karamel-nofstar.opam
	[WARNING] Failed checks on karamel-nofstar package definition from source at git+file:///home/opam/FStar/karamel#master:
	error  3: File format error in 'url': missing URL
	warning 35: Missing field 'homepage'
	warning 36: Missing field 'bug-reports'
	Nothing to do.

Add karamel-nofstar.opam to gitignore while at it.