### PR TITLE
Makefiles: allow minimal build and cleaning without F*

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,10 @@ else
     FSTAR_HOME=$(dir $(FSTAR_EXE))/..
     OCAMLPATH:=$(OCAMLPATH)$(OCAMLPATH_SEP)$(FSTAR_HOME)/lib
   else
-    $(error "fstar.exe not found, please install FStar")
+    # If we are just trying to do a minimal build, we don't need F*.
+    ifneq ($(MAKECMDGOALS),minimal)
+      $(error "fstar.exe not found, please install FStar")
+    endif
   endif
 endif
 export FSTAR_HOME

--- a/book/tutorial/Makefile
+++ b/book/tutorial/Makefile
@@ -86,7 +86,7 @@ FSTAR_ROOTS = $(wildcard $(addsuffix /*.fsti,$(SOURCE_DIRS))) \
 # mtime of the moved files.
 ifndef MAKE_RESTARTS
 .depend: .FORCE
-	$(FSTAR_NO_FLAGS) --dep full $(notdir $(FSTAR_ROOTS)) $(FSTAR_EXTRACT) > $@
+	$(FSTAR_NO_FLAGS) --dep full $(notdir $(FSTAR_ROOTS)) $(FSTAR_EXTRACT) --output_deps_to $@
 
 .PHONY: .FORCE
 .FORCE:

--- a/krmllib/Makefile
+++ b/krmllib/Makefile
@@ -66,7 +66,7 @@ clean-c:
 ifndef NODEPEND
 ifndef MAKE_RESTARTS
 .depend: .FORCE obj
-	$(FSTAR) $(OTHERFLAGS) --dep full $(ROOTS) > $@
+	$(FSTAR) $(OTHERFLAGS) --dep full $(ROOTS) --output_deps_to $@
 
 .PHONY: .FORCE
 .FORCE:

--- a/test/Makefile
+++ b/test/Makefile
@@ -100,7 +100,7 @@ ifndef MAKE_RESTARTS
 ifndef NODEPEND
 .depend: .FORCE
 	$(FSTAR) --dep full $(subst .wasm-test,.fst,$(WASM_FILES)) $(subst .test,.fst,$(FILES)) \
-	  $(BROKEN) ../runtime/WasmSupport.fst --extract 'krml:*,-Prims' > $@
+	  $(BROKEN) ../runtime/WasmSupport.fst --extract 'krml:*,-Prims' --output_deps_to $@
 
 .PHONY: .FORCE
 .FORCE:

--- a/test/sepcomp/a/Makefile
+++ b/test/sepcomp/a/Makefile
@@ -68,7 +68,7 @@ FSTAR_ROOTS = $(wildcard $(addsuffix /*.fsti,$(SOURCE_DIRS))) \
 ifndef MAKE_RESTARTS
 obj/.depend: .FORCE
 	mkdir -p obj
-	$(FSTAR_NO_FLAGS) --dep full $(notdir $(FSTAR_ROOTS)) $(FSTAR_EXTRACT) > $@
+	$(FSTAR_NO_FLAGS) --dep full $(notdir $(FSTAR_ROOTS)) $(FSTAR_EXTRACT) --output_deps_to $@
 
 .PHONY: .FORCE
 .FORCE:

--- a/test/sepcomp/b/Makefile
+++ b/test/sepcomp/b/Makefile
@@ -69,7 +69,7 @@ FSTAR_ROOTS = $(wildcard $(addsuffix /*.fsti,$(SOURCE_DIRS))) \
 ifndef MAKE_RESTARTS
 obj/.depend: .FORCE
 	mkdir -p obj
-	$(FSTAR_NO_FLAGS) --dep full $(notdir $(FSTAR_ROOTS)) $(FSTAR_EXTRACT) > $@
+	$(FSTAR_NO_FLAGS) --dep full $(notdir $(FSTAR_ROOTS)) $(FSTAR_EXTRACT) --output_deps_to $@
 
 .PHONY: .FORCE
 .FORCE:


### PR DESCRIPTION
Hi Jonathan, this patch would allow to save some CI time by building karamel (`make minimal`) in parallel with F* and build the library only later, saving some time (though not much). Do you think it makes sense?

I could do the same thing for `clean`, avoiding the generation of `.depend`.

Also a tiny improvement to prevent against creating empty `.depend`s.