### PR TITLE
tests: ctypes: fix build breakage, use ctypes.foreign and -thread

### DIFF
--- a/test/ctypes/Makefile
+++ b/test/ctypes/Makefile
@@ -22,9 +22,9 @@ libdemo.a: $(ALL_O_FILES)
 
 .PRECIOUS: %.cmx %.cmi %.cmo
 
-OCAMLOPT=ocamlfind opt -package ctypes,ctypes.stubs -linkpkg -I lib -I .
+OCAMLOPT=ocamlfind opt -package ctypes,ctypes.foreign,ctypes.stubs -linkpkg -I lib -I .
 OCAMLDEP=ocamlfind dep -I lib -slash
-OCAMLC	=ocamlfind c -g -package ctypes,ctypes.stubs -linkpkg -I lib -I .
+OCAMLC	=ocamlfind c -thread -g -package ctypes,ctypes.foreign,ctypes.stubs -linkpkg -I lib -I .
 
 CFLAGS += -I "$(shell ocamlfind query ctypes)" -I "$(shell ocamlfind c -where)" 
 


### PR DESCRIPTION
Got an everest green with this.