### PR TITLE
Bring anonymous unions into the data type monomorphization / reordering phase

### DIFF
--- a/krmllib/hints/C.Endianness.fst.hints
+++ b/krmllib/hints/C.Endianness.fst.hints
@@ -8,7 +8,7 @@
       1,
       [ "@query" ],
       0,
-      "c169be3b83d65c25442276d4189d1094"
+      "c9d34bcf6778bfc0790376dfadcef8db"
     ],
     [
       "C.Endianness.load16_le",
@@ -17,7 +17,7 @@
       1,
       [ "@query" ],
       0,
-      "40ddeab37331235095f5a8ca8019ea32"
+      "fe4e04c45bc5e329624af624b98244a8"
     ],
     [
       "C.Endianness.store16_be",
@@ -26,7 +26,7 @@
       1,
       [ "@query" ],
       0,
-      "d7b2259c7519b424ab82f96c2cb7ee1c"
+      "7bd646f6ad066cd2d9062881a8dd706d"
     ],
     [
       "C.Endianness.load16_be",
@@ -35,7 +35,7 @@
       1,
       [ "@query" ],
       0,
-      "53c45c7319eddd769b8ea335faa7112e"
+      "6e63448840659662fb015859f76946ff"
     ],
     [
       "C.Endianness.store32_le",
@@ -44,7 +44,7 @@
       1,
       [ "@query" ],
       0,
-      "952bf736735cc5fb5664f5e5920a8fea"
+      "54551ec36ebd61476a48ffb80533976d"
     ],
     [
       "C.Endianness.load32_le",
@@ -53,7 +53,7 @@
       1,
       [ "@query" ],
       0,
-      "28d7c02584d5cbe5b86201d3d8426579"
+      "3f7c927994fac79138e377a351423ab5"
     ],
     [
       "C.Endianness.store32_be",
@@ -62,7 +62,7 @@
       1,
       [ "@query" ],
       0,
-      "53f7e5471c9ad13f3968f5800ef7d6d7"
+      "89b392d90cf11908818a40beed0cc15e"
     ],
     [
       "C.Endianness.load32_be",
@@ -71,7 +71,7 @@
       1,
       [ "@query" ],
       0,
-      "012ed2b3372df40aef59568595b50b63"
+      "873640614d7be5cd7401ae82f5ed93c3"
     ],
     [
       "C.Endianness.store64_le",
@@ -80,7 +80,7 @@
       1,
       [ "@query" ],
       0,
-      "9d04d730e191eb5cbf16f6dcbcf24b8e"
+      "38d68ebf8e57890e1604bb36e6afeb8c"
     ],
     [
       "C.Endianness.load64_le",
@@ -89,7 +89,7 @@
       1,
       [ "@query" ],
       0,
-      "359229714b48401a3aa396eeb89c40b6"
+      "79d4383b822662f66ebc77b47a9fdca1"
     ],
     [
       "C.Endianness.load64_be",
@@ -98,7 +98,7 @@
       1,
       [ "@query" ],
       0,
-      "ec380a36cc4bf2de42b70770b6cf2306"
+      "c83bf600bbdf73f0ed25d9086da2ebfd"
     ],
     [
       "C.Endianness.store64_be",
@@ -107,7 +107,7 @@
       1,
       [ "@query" ],
       0,
-      "b1413ef7f714a95e0905e7368dc60b0f"
+      "d6ec1a03460819508400985b3d7dde4a"
     ],
     [
       "C.Endianness.load128_le",
@@ -119,7 +119,7 @@
         "projection_inverse_BoxInt_proj_0"
       ],
       0,
-      "ef637848037e08504465826f4b83245a"
+      "c11d7ab6ddb61dbed2379a9b17323b94"
     ],
     [
       "C.Endianness.store128_le",
@@ -131,7 +131,7 @@
         "projection_inverse_BoxInt_proj_0"
       ],
       0,
-      "210cffe9e5c99c41f9761c637e753ef1"
+      "7bf4dfee1e0fad233051b2174b8abdc2"
     ],
     [
       "C.Endianness.load128_be",
@@ -143,7 +143,7 @@
         "projection_inverse_BoxInt_proj_0"
       ],
       0,
-      "55167a3b78dd7d6ef0bfda1457b51eef"
+      "5048141f8cdb76020293dfc0ee81629b"
     ],
     [
       "C.Endianness.store128_be",
@@ -155,7 +155,7 @@
         "projection_inverse_BoxInt_proj_0"
       ],
       0,
-      "0959e5467ff3a6b228ee7a8191e2a115"
+      "d91999b16fbcbd8a59f79f890fa9b3f9"
     ],
     [
       "C.Endianness.index_32_be",
@@ -219,7 +219,7 @@
         "typing_LowStar.Monotonic.Buffer.loc_none"
       ],
       0,
-      "b2f11c8a4cc08681641d7a849fdfc61f"
+      "6c4d394691bb92fbca9319130d4adfc7"
     ],
     [
       "C.Endianness.index_32_le",
@@ -281,7 +281,7 @@
         "typing_LowStar.Monotonic.Buffer.loc_none"
       ],
       0,
-      "c9710cf97cccf4626be5422a7adc01b3"
+      "cc0c371b3cb513063be51f6b2e74bbcc"
     ],
     [
       "C.Endianness.index_64_be",
@@ -344,7 +344,7 @@
         "typing_LowStar.Monotonic.Buffer.loc_none"
       ],
       0,
-      "72bd473fddbec79ee234af0e193d34ac"
+      "6e8a57e5a3e369c4aba71c43e6902075"
     ],
     [
       "C.Endianness.index_64_le",
@@ -404,7 +404,7 @@
         "typing_LowStar.Monotonic.Buffer.loc_none"
       ],
       0,
-      "f81cb1a8b296949f411fca62dc53fd2a"
+      "9e8a9b89d379e274cb66ac0959d708b0"
     ],
     [
       "C.Endianness.interval_4_disjoint",
@@ -421,7 +421,7 @@
         "refinement_interpretation_Tm_refine_542f9d4f129664613f2483a6c88bc7c2"
       ],
       0,
-      "322a88eecdf47cc54ae8e3d01dd2caae"
+      "f193c9be1a2531a781a7155c11de8e49"
     ],
     [
       "C.Endianness.upd_32_be",
@@ -500,7 +500,7 @@
         "typing_LowStar.Monotonic.Buffer.loc_buffer"
       ],
       0,
-      "c7a3835b34c58b2c2e765a90ee6f6564"
+      "7b44eef528eb5959c7d41e1bea07737b"
     ]
   ]
 ]

--- a/krmllib/hints/C.Failure.fst.hints
+++ b/krmllib/hints/C.Failure.fst.hints
@@ -20,7 +20,7 @@
         "typing_FStar.Monotonic.HyperStack.get_hmap"
       ],
       0,
-      "856f471dedbfbeda40e0d7b3db09534f"
+      "6f8be508545c6199c4eee93284fd252e"
     ],
     [
       "C.Failure.failwith",
@@ -29,7 +29,7 @@
       1,
       [ "@query" ],
       0,
-      "8907ff306b96125f892c19b00553cb1a"
+      "c49ca2463f9e75e72dcbff81cc52ea51"
     ]
   ]
 ]

--- a/krmllib/hints/C.Loops.fst.hints
+++ b/krmllib/hints/C.Loops.fst.hints
@@ -20,7 +20,7 @@
         "typing_FStar.UInt32.v"
       ],
       0,
-      "8d9287b3e066440058284c21e7158f44"
+      "31fb85fd12fd8438164c7d9a7d7254a9"
     ],
     [
       "C.Loops.for",
@@ -40,7 +40,7 @@
         "typing_FStar.UInt32.v"
       ],
       0,
-      "1f2584202dae0b38eaae8c6d8b4649e7"
+      "06e36ee5d741120e7589f5af151fbab7"
     ],
     [
       "C.Loops.for",
@@ -80,7 +80,7 @@
         "typing_FStar.Monotonic.HyperStack.get_tip", "typing_FStar.UInt32.v"
       ],
       0,
-      "7f5195d406cde7b73b5d4fa3064196ec"
+      "835a052174c55d39e1973f4472127e48"
     ],
     [
       "C.Loops.for64",
@@ -101,7 +101,7 @@
         "typing_FStar.UInt64.v"
       ],
       0,
-      "427be09388d6d99247c574bc1f7561b2"
+      "93c156d8985f723fdd151bea6376905b"
     ],
     [
       "C.Loops.for64",
@@ -121,7 +121,7 @@
         "typing_FStar.UInt64.v"
       ],
       0,
-      "8f9fe652f25d5a8adaf8757e497d9042"
+      "b0283719129c7dd9039ce441c2a88d52"
     ],
     [
       "C.Loops.for64",
@@ -161,7 +161,7 @@
         "typing_FStar.Monotonic.HyperStack.get_tip", "typing_FStar.UInt64.v"
       ],
       0,
-      "3c696a15be847fe6864bb3eaeba9645b"
+      "5b5c4f289aa03d7992ec5fbde658db3b"
     ],
     [
       "C.Loops.reverse_for",
@@ -183,7 +183,7 @@
         "typing_FStar.UInt32.v"
       ],
       0,
-      "aa4c05188817c66300f2998306464694"
+      "155bf3a6b26b807c7cc0e1f079da340a"
     ],
     [
       "C.Loops.reverse_for",
@@ -205,7 +205,7 @@
         "typing_FStar.UInt32.v"
       ],
       0,
-      "1d8a583bf0b825f7c68e842ebb5c6ab0"
+      "59387c6919ac5b832f62c00cc87db426"
     ],
     [
       "C.Loops.reverse_for",
@@ -246,7 +246,7 @@
         "typing_FStar.Monotonic.HyperStack.get_tip", "typing_FStar.UInt32.v"
       ],
       0,
-      "059515481a0e22c9a9b965b66aaefc5d"
+      "dc2a5544e67e2311f65862319013e381"
     ],
     [
       "C.Loops.interruptible_for",
@@ -266,7 +266,7 @@
         "typing_FStar.UInt32.v"
       ],
       0,
-      "075ca8e589936f52dec34ed5bccf0e5b"
+      "739db4360686742847e5a2ac7c96f309"
     ],
     [
       "C.Loops.interruptible_for",
@@ -286,7 +286,7 @@
         "typing_FStar.UInt32.v"
       ],
       0,
-      "fa43b607e65360d90b6f11a773bf5a2c"
+      "b49462be07af2f4a6715419c66ae3ca9"
     ],
     [
       "C.Loops.interruptible_for",
@@ -330,7 +330,7 @@
         "typing_FStar.Monotonic.HyperStack.get_tip", "typing_FStar.UInt32.v"
       ],
       0,
-      "a11b725570d7f91cffcf27e399e696c8"
+      "d33afb5f0223496774e7c1a26a3dcbdd"
     ],
     [
       "C.Loops.do_while",
@@ -355,7 +355,7 @@
         "typing_FStar.Monotonic.HyperStack.get_tip"
       ],
       0,
-      "1c78497bf9e7dbd1c67156e6e86e8c08"
+      "fa010a0cf1b8730687ffc05157f32b16"
     ],
     [
       "C.Loops.while",
@@ -369,7 +369,7 @@
         "refinement_interpretation_Tm_refine_b16bf82b210653a34e4d7322fab91ffb"
       ],
       0,
-      "7cbc066ad5c70531be3aa67320d0097f"
+      "18b77ecdf68a6e2e8bb8d3fd402b2913"
     ],
     [
       "C.Loops.interruptible_reverse_for",
@@ -391,7 +391,7 @@
         "typing_FStar.UInt32.v"
       ],
       0,
-      "ae678a3271774060341fddd4905b44c3"
+      "d7eeac7d87c6a63192b85f3bca0bfba9"
     ],
     [
       "C.Loops.interruptible_reverse_for",
@@ -413,7 +413,7 @@
         "typing_FStar.UInt32.v"
       ],
       0,
-      "0daba00c08efeebfe64e47020825cf6b"
+      "c99e1c37160e1f20ca5441998b253204"
     ],
     [
       "C.Loops.interruptible_reverse_for",
@@ -458,7 +458,7 @@
         "typing_FStar.Monotonic.HyperStack.get_tip", "typing_FStar.UInt32.v"
       ],
       0,
-      "fbfd18f660d2f35addafe2045e261d1a"
+      "e1bddf1c5fa54c782b51a1d4a570b166"
     ],
     [
       "C.Loops.map",
@@ -467,7 +467,7 @@
       1,
       [ "@query" ],
       0,
-      "29ee45cd49dbf5af34da5fd2abde751f"
+      "d892671a970a83107b70c1a24112d50b"
     ],
     [
       "C.Loops.map",
@@ -476,7 +476,7 @@
       1,
       [ "@query" ],
       0,
-      "7ba2e714d2397725d3d2c700caf0b7d7"
+      "f4a0e1f75e9a2e8d8ce0978aeb6c7bc6"
     ],
     [
       "C.Loops.map",
@@ -525,7 +525,7 @@
         "typing_Spec.Loops.seq_map"
       ],
       0,
-      "5e03ac0153e1f3b479f4c680092e51e3"
+      "feb0cdda69dd3adf2a6ff8223148e02c"
     ],
     [
       "C.Loops.map2",
@@ -540,7 +540,7 @@
         "typing_LowStar.Buffer.trivial_preorder"
       ],
       0,
-      "ee0644c200de3ba9b262a92c90aa4d30"
+      "f389db4ed8231591aadff57079e819e5"
     ],
     [
       "C.Loops.map2",
@@ -549,7 +549,7 @@
       1,
       [ "@query" ],
       0,
-      "253bd94dd05c5f5cbb579e399a8571af"
+      "9e6dba160f789e13d440d1fc71ac313d"
     ],
     [
       "C.Loops.map2",
@@ -598,7 +598,7 @@
         "typing_LowStar.Monotonic.Buffer.loc_buffer"
       ],
       0,
-      "9efb94014cbe78ede9341510021ff9cb"
+      "007391b0906b4c2333241a3508b312fe"
     ],
     [
       "C.Loops.in_place_map",
@@ -607,7 +607,7 @@
       1,
       [ "@query" ],
       0,
-      "f0652ed3d5a6b2cc0e06ff60fc5028ca"
+      "799b8a7cae5c42700b5b3ffda8eaf37c"
     ],
     [
       "C.Loops.in_place_map",
@@ -616,7 +616,7 @@
       1,
       [ "@query" ],
       0,
-      "a01980cf9e00caa2f7657719e7457fa9"
+      "9f3afffdd09635fc23d20619619d708e"
     ],
     [
       "C.Loops.in_place_map",
@@ -661,7 +661,7 @@
         "typing_Spec.Loops.seq_map"
       ],
       0,
-      "b4b1614a32d4f4efbbb9b2a3a41bcfdb"
+      "0dbb9394e965dd49365ab62c721e0c43"
     ],
     [
       "C.Loops.in_place_map2",
@@ -676,7 +676,7 @@
         "typing_LowStar.Buffer.trivial_preorder"
       ],
       0,
-      "c60dc6ecb381c4eb83ad168cd581c2ed"
+      "182937a9a11993f770db95dccb814a0a"
     ],
     [
       "C.Loops.in_place_map2",
@@ -685,7 +685,7 @@
       1,
       [ "@query" ],
       0,
-      "fe57795e652ce2938a6ac847cfe9bb3d"
+      "868abe11732931ff5cb6a4fc3b9d5f92"
     ],
     [
       "C.Loops.in_place_map2",
@@ -732,7 +732,7 @@
         "typing_LowStar.Monotonic.Buffer.loc_buffer"
       ],
       0,
-      "860a231f9b03098e4263f4f7f82df23c"
+      "668c7b963d5a1db2046ff02a85126b03"
     ],
     [
       "C.Loops.repeat",
@@ -755,7 +755,7 @@
         "typing_LowStar.Buffer.trivial_preorder"
       ],
       0,
-      "bfa1c15ac6ffd2b16b162f8aa5b2433a"
+      "7dde7c54490255f073b68b7325cb0044"
     ],
     [
       "C.Loops.repeat",
@@ -773,7 +773,7 @@
         "typing_LowStar.Buffer.trivial_preorder"
       ],
       0,
-      "0e69848d65f341ee2d6eef9bfef92c04"
+      "d1ec8c997ccabdbc800e245fc27428a3"
     ],
     [
       "C.Loops.repeat",
@@ -806,7 +806,7 @@
         "typing_LowStar.Monotonic.Buffer.loc_buffer"
       ],
       0,
-      "48f804117d1f3da936648878a5fe786d"
+      "0515b06d658f5bccb5be351ffe8a8ba3"
     ],
     [
       "C.Loops.repeat_range_body_impl",
@@ -820,7 +820,7 @@
         "projection_inverse_BoxBool_proj_0"
       ],
       0,
-      "24f92f55dabd213e4c90787ec3e11ad8"
+      "6dfcaac110fe9e79c0efd2d581487aa6"
     ],
     [
       "C.Loops.repeat_range_body_impl",
@@ -839,7 +839,7 @@
         "typing_FStar.UInt32.v"
       ],
       0,
-      "80218e1d21bead58422689ce2cefd36e"
+      "354e3e3725c3ad51a75f7dad7d3657e4"
     ],
     [
       "C.Loops.repeat_range",
@@ -858,7 +858,7 @@
         "typing_FStar.UInt32.v"
       ],
       0,
-      "0c1e526cfe1e30e8bf86533efaa6d543"
+      "423de022d5c08c0098dc0250c1e04630"
     ],
     [
       "C.Loops.repeat_range",
@@ -872,7 +872,7 @@
         "projection_inverse_BoxBool_proj_0"
       ],
       0,
-      "c022b5171621ee29981403fb8123dc94"
+      "5bbdd69986292661b00f0de26ed93660"
     ],
     [
       "C.Loops.repeat_range",
@@ -897,7 +897,7 @@
         "typing_FStar.UInt32.v"
       ],
       0,
-      "64a16fab8f90acd18abd1662ad0051f2"
+      "085e9998367f132718f978d8081c93a9"
     ],
     [
       "C.Loops.total_while_gen",
@@ -912,7 +912,7 @@
         "equality_tok_Prims.LexTop@tok", "typing_tok_Prims.LexTop@tok"
       ],
       0,
-      "9dffae296e845b0a2e79855055d4c681"
+      "337809267aa59497aad74a3145b29995"
     ],
     [
       "C.Loops.total_while",
@@ -932,7 +932,7 @@
         "well-founded-ordering-on-nat"
       ],
       0,
-      "e1e8fc1c7e2ac737ce444ff5676f27b5"
+      "66b8d70971636df36834d354aa711741"
     ]
   ]
 ]

--- a/krmllib/hints/C.String.fst.hints
+++ b/krmllib/hints/C.String.fst.hints
@@ -11,7 +11,7 @@
         "primitive_Prims.op_Subtraction", "projection_inverse_BoxInt_proj_0"
       ],
       0,
-      "8199debc3531f5752d95bde9f9b79676"
+      "20998be05058c9f55e9ade2c13cd5914"
     ],
     [
       "C.String.well_formed",
@@ -23,7 +23,7 @@
         "primitive_Prims.op_Subtraction", "projection_inverse_BoxInt_proj_0"
       ],
       0,
-      "20e94bfa590d06c2ecafbf90c1c880b5"
+      "d4a774bfe694c86ea095788a5e426939"
     ],
     [
       "C.String.t",
@@ -35,7 +35,7 @@
         "lemma_FStar.Seq.Base.hasEq_lemma"
       ],
       0,
-      "e0a2c3b74f1580994c9dab759374d9f0"
+      "649bec79ff70458783f94bff3cf55828"
     ],
     [
       "C.String.length",
@@ -50,7 +50,7 @@
         "refinement_interpretation_Tm_refine_ed6e8a85e123e1e628ba0dad885f3031"
       ],
       0,
-      "2ca29b30fc6e22607ae9e52b63a5b594"
+      "a96ca03f93bf010ec086ed4ad0a5f7a1"
     ],
     [
       "C.String.get",
@@ -66,7 +66,7 @@
         "refinement_interpretation_Tm_refine_dfcb8c150fd42ce38050af33905be19c"
       ],
       0,
-      "a8b6d1e7526c41b4bb59f4086a04ae3b"
+      "19d20c20c4813d58458b0cdf9d19fc5d"
     ],
     [
       "C.String.get",
@@ -85,7 +85,7 @@
         "typing_FStar.UInt32.v"
       ],
       0,
-      "4b3b22f7c4b74b59527af1bafb3b9cb1"
+      "951c57ed2d106a12b225643181a48611"
     ],
     [
       "C.String.nonzero_is_lt",
@@ -98,7 +98,7 @@
         "fuel_guarded_inversion_C.String.t"
       ],
       0,
-      "7fc7bee7b92cae9c13876b6d165cb8d7"
+      "ddfa8e4791c667f476f421e5da21ca4b"
     ],
     [
       "C.String.nonzero_is_lt",
@@ -119,7 +119,7 @@
         "typing_FStar.UInt32.v"
       ],
       0,
-      "4ec454f3161cb964a69fa1a16a704a60"
+      "9b080ffd63f7ecf92654cbbe94894ffa"
     ],
     [
       "C.String.memcpy",
@@ -133,7 +133,7 @@
         "typing_FStar.UInt8.t"
       ],
       0,
-      "11fc25db30e1b37cd2f4c0e87a6b74d3"
+      "39be42230e2af2bea1766eacb6879849"
     ]
   ]
 ]

--- a/krmllib/hints/C.String.fsti.hints
+++ b/krmllib/hints/C.String.fsti.hints
@@ -11,7 +11,7 @@
         "primitive_Prims.op_Subtraction", "projection_inverse_BoxInt_proj_0"
       ],
       0,
-      "6da1ffbb373a6d77f784ea85f56486b0"
+      "81c77f071e305842de5dd82f00438752"
     ],
     [
       "C.String.well_formed",
@@ -23,7 +23,7 @@
         "primitive_Prims.op_Subtraction", "projection_inverse_BoxInt_proj_0"
       ],
       0,
-      "c8dd585c4438e9058ff64042853649d6"
+      "c7a031195c6cf6099def507f27c9974b"
     ],
     [
       "C.String.get",
@@ -39,7 +39,7 @@
         "refinement_interpretation_Tm_refine_dfcb8c150fd42ce38050af33905be19c"
       ],
       0,
-      "ba3875c02ecd9b6e98878ef32403e9a2"
+      "c7254a39e0d22a0ee0b9f254b4bb0231"
     ],
     [
       "C.String.nonzero_is_lt",
@@ -52,7 +52,7 @@
         "typing_C.String.length"
       ],
       0,
-      "9e14a981a8f58f98195060396f76b413"
+      "1467a083148e144cd64727b843d38393"
     ],
     [
       "C.String.memcpy",
@@ -66,7 +66,7 @@
         "typing_FStar.UInt8.t"
       ],
       0,
-      "ee70a9aad26c2748b84b491a2fc48eef"
+      "780ece28169491a93acf4f3b19c0d9e0"
     ]
   ]
 ]

--- a/krmllib/hints/C.fst.hints
+++ b/krmllib/hints/C.fst.hints
@@ -8,7 +8,7 @@
       1,
       [ "@query", "assumption_C.HasEq_char" ],
       0,
-      "2e8bebe8d983358f214284205342bc9c"
+      "19c413cc3b811635b00d9877daecd4ed"
     ]
   ]
 ]

--- a/krmllib/hints/FStar.Krml.Endianness.fst.hints
+++ b/krmllib/hints/FStar.Krml.Endianness.fst.hints
@@ -32,7 +32,7 @@
         "well-founded-ordering-on-nat"
       ],
       0,
-      "20c786d2f70f1f8fc281f1b6b2d04062"
+      "87df503cbca29c64e0141b699bbfb232"
     ],
     [
       "FStar.Krml.Endianness.be_to_n",
@@ -65,7 +65,7 @@
         "well-founded-ordering-on-nat"
       ],
       0,
-      "5cb900fc718949a60beb5ca563159234"
+      "e944e967333c073bfaa6293ad56f2bb2"
     ],
     [
       "FStar.Krml.Endianness.lemma_euclidean_division",
@@ -77,7 +77,7 @@
         "primitive_Prims.op_Multiply", "projection_inverse_BoxInt_proj_0"
       ],
       0,
-      "91d94bf6e9762c1562be95bc9a68eb97"
+      "956be6d46d2fa4f744b1c12a2dcc718e"
     ],
     [
       "FStar.Krml.Endianness.lemma_factorise",
@@ -89,7 +89,7 @@
         "primitive_Prims.op_Multiply", "projection_inverse_BoxInt_proj_0"
       ],
       0,
-      "0e0e0a3ea5486c5600ebc7363fbc9e6d"
+      "1563e8d32d0636e62e61910a6a409a02"
     ],
     [
       "FStar.Krml.Endianness.lemma_le_to_n_is_bounded",
@@ -106,7 +106,7 @@
         "typing_FStar.Seq.Base.length", "typing_FStar.UInt8.t"
       ],
       0,
-      "15cc73aa8d45739788009b99e9be2788"
+      "50cd8f88248a197cfb8fbd6468ee5429"
     ],
     [
       "FStar.Krml.Endianness.lemma_le_to_n_is_bounded",
@@ -124,7 +124,7 @@
         "typing_FStar.Seq.Base.length", "typing_FStar.UInt8.t"
       ],
       0,
-      "1535b21ffff7f312b27b8e901ca8923e"
+      "03bfa9fbc0b0368236dcb2c3a578a25f"
     ],
     [
       "FStar.Krml.Endianness.lemma_le_to_n_is_bounded",
@@ -166,7 +166,7 @@
         "typing_Prims.pow2", "well-founded-ordering-on-nat"
       ],
       0,
-      "21595e6b789dd886767b53648b6bd8f3"
+      "ed62b883408c058205556d13b40f791f"
     ],
     [
       "FStar.Krml.Endianness.lemma_be_to_n_is_bounded",
@@ -183,7 +183,7 @@
         "typing_FStar.Seq.Base.length", "typing_FStar.UInt8.t"
       ],
       0,
-      "170cae1fde2a8eb25ed322504b294b51"
+      "8c4a46c6df4a6035bfd3c9011812b058"
     ],
     [
       "FStar.Krml.Endianness.lemma_be_to_n_is_bounded",
@@ -201,7 +201,7 @@
         "typing_FStar.Seq.Base.length", "typing_FStar.UInt8.t"
       ],
       0,
-      "49b544c9f43657fc072784457f6e791d"
+      "199cb63602a5eabc097a64668b70a6b1"
     ],
     [
       "FStar.Krml.Endianness.lemma_be_to_n_is_bounded",
@@ -240,7 +240,7 @@
         "typing_Prims.pow2", "well-founded-ordering-on-nat"
       ],
       0,
-      "f82278300e648bd014ffd8cb795650f7"
+      "75558ea2f9d60489555f20f07c559907"
     ],
     [
       "FStar.Krml.Endianness.n_to_le",
@@ -259,7 +259,7 @@
         "typing_FStar.UInt32.v"
       ],
       0,
-      "f5a4708be680f75481cdf18cbcc930ee"
+      "0a4803af0b0853bd9327d6ad202cfcb9"
     ],
     [
       "FStar.Krml.Endianness.n_to_le",
@@ -278,7 +278,7 @@
         "typing_FStar.UInt32.v"
       ],
       0,
-      "5f1ff8e557869d50c117fb314534fbfe"
+      "5cc71fde525356dd6f75ca9072dec3c5"
     ],
     [
       "FStar.Krml.Endianness.n_to_le",
@@ -341,7 +341,7 @@
         "typing_FStar.UInt8.t", "well-founded-ordering-on-nat"
       ],
       0,
-      "123be248fe4e5f0cf2b1c4db3317f0f2"
+      "47177eda1adca53726648d9a49a97df2"
     ],
     [
       "FStar.Krml.Endianness.n_to_be",
@@ -360,7 +360,7 @@
         "typing_FStar.UInt32.v"
       ],
       0,
-      "8ac0ee3cac762e32a567a0b339297a14"
+      "a506ee2db425baf6cdeaf576d16add6a"
     ],
     [
       "FStar.Krml.Endianness.n_to_be",
@@ -379,7 +379,7 @@
         "typing_FStar.UInt32.v"
       ],
       0,
-      "af57674073da6242ecbe6435b158016d"
+      "35cf9be20fbd6119964378328ce77770"
     ],
     [
       "FStar.Krml.Endianness.n_to_be",
@@ -442,7 +442,7 @@
         "well-founded-ordering-on-nat"
       ],
       0,
-      "aa1626e1ca05a07addefd14ee2668762"
+      "c93eb60a1007639f81a9f2fe18e425b0"
     ],
     [
       "FStar.Krml.Endianness.n_to_le_inj",
@@ -461,7 +461,7 @@
         "typing_FStar.UInt32.v"
       ],
       0,
-      "2a88237633db248ffd1ac1a0c2e5bf6e"
+      "8d6eb2d61369b820fff7565439e9ddd3"
     ],
     [
       "FStar.Krml.Endianness.n_to_le_inj",
@@ -483,7 +483,7 @@
         "typing_FStar.Krml.Endianness.n_to_le", "typing_FStar.UInt32.v"
       ],
       0,
-      "227399bc4a23f0d466f2e8dda8b2a93c"
+      "9ec5eb0af42b20a2f9d12d0dc060fb48"
     ],
     [
       "FStar.Krml.Endianness.n_to_be_inj",
@@ -502,7 +502,7 @@
         "typing_FStar.UInt32.v"
       ],
       0,
-      "1bd57f0572317d10c80dcf155de9e7a2"
+      "eae0590b5b3997af6d6986d28985e37d"
     ],
     [
       "FStar.Krml.Endianness.n_to_be_inj",
@@ -524,7 +524,7 @@
         "typing_FStar.Krml.Endianness.n_to_be", "typing_FStar.UInt32.v"
       ],
       0,
-      "68932f04e80451763a9809ded0ece79e"
+      "7b2128c444e573531a55781f43f375b1"
     ],
     [
       "FStar.Krml.Endianness.be_to_n_inj",
@@ -580,7 +580,7 @@
         "well-founded-ordering-on-nat"
       ],
       0,
-      "d50d27f3deff07993f962f3b1dd52a94"
+      "fb15933fff704d6f179d1db245c283ef"
     ],
     [
       "FStar.Krml.Endianness.le_to_n_inj",
@@ -637,7 +637,7 @@
         "typing_FStar.UInt8.v", "well-founded-ordering-on-nat"
       ],
       0,
-      "0d47fb7a1486ea016a18a71bb4b46bbb"
+      "589134a951142aff46ad840d38f546ec"
     ],
     [
       "FStar.Krml.Endianness.n_to_be_be_to_n",
@@ -656,7 +656,7 @@
         "typing_FStar.Seq.Base.length", "typing_FStar.UInt8.t"
       ],
       0,
-      "915af67347f86c37da04fa2c5b688ab7"
+      "468eef2509abc430aa6bf64bebd442ec"
     ],
     [
       "FStar.Krml.Endianness.n_to_le_le_to_n",
@@ -675,7 +675,7 @@
         "typing_FStar.Seq.Base.length", "typing_FStar.UInt8.t"
       ],
       0,
-      "ad3c366130c5a04d058c9c8698e22011"
+      "a81b6357f26c1aa9d343ab40fd815d40"
     ],
     [
       "FStar.Krml.Endianness.uint32_of_le",
@@ -695,7 +695,7 @@
         "refinement_interpretation_Tm_refine_073e087ab5f9fabfeddf43c4ff72a1d0"
       ],
       0,
-      "8c3d47cc5d15383c94c778a55ec64ebc"
+      "52402518482fa532ec2e7f233f33d7bf"
     ],
     [
       "FStar.Krml.Endianness.le_of_uint32",
@@ -712,7 +712,7 @@
         "projection_inverse_BoxInt_proj_0"
       ],
       0,
-      "1ec5b2efb42b6e9bd9e27189ad721736"
+      "06a12c31d800cd3958596d86535e6819"
     ],
     [
       "FStar.Krml.Endianness.uint32_of_be",
@@ -732,7 +732,7 @@
         "refinement_interpretation_Tm_refine_073e087ab5f9fabfeddf43c4ff72a1d0"
       ],
       0,
-      "19c2edf6039b8b5f0c4c5e7259a112e2"
+      "c1995f846bbe91ddccceaf3a006f72c0"
     ],
     [
       "FStar.Krml.Endianness.be_of_uint32",
@@ -749,7 +749,7 @@
         "projection_inverse_BoxInt_proj_0"
       ],
       0,
-      "07b99f864e3337ef427d0a87d388cf23"
+      "d277b838a471f87d7961509284a11a8c"
     ],
     [
       "FStar.Krml.Endianness.uint64_of_le",
@@ -769,7 +769,7 @@
         "refinement_interpretation_Tm_refine_1cb22d5b190a69600ef23f524d7a6d8a"
       ],
       0,
-      "615ba005889eddf39cb447384fca1ad2"
+      "e0ae3dadaeee80a4e1c0424ac5d9c314"
     ],
     [
       "FStar.Krml.Endianness.le_of_uint64",
@@ -786,7 +786,7 @@
         "projection_inverse_BoxInt_proj_0"
       ],
       0,
-      "1462a6126164663568039b5362cdf01a"
+      "2e43640693bc9f16965e2ea4a09b9633"
     ],
     [
       "FStar.Krml.Endianness.uint64_of_be",
@@ -806,7 +806,7 @@
         "refinement_interpretation_Tm_refine_1cb22d5b190a69600ef23f524d7a6d8a"
       ],
       0,
-      "0d08c28b147284f2ba596f7db18489be"
+      "19d4e3e1b6537e0ad7831665a49b5fa8"
     ],
     [
       "FStar.Krml.Endianness.be_of_uint64",
@@ -823,7 +823,7 @@
         "projection_inverse_BoxInt_proj_0"
       ],
       0,
-      "0a79f49b8833b73a5c253d97aba79c86"
+      "c49d6fde9d71e43e7532d89999ad4da7"
     ],
     [
       "FStar.Krml.Endianness.seq_uint32_of_le",
@@ -837,7 +837,7 @@
         "refinement_interpretation_Tm_refine_414d0a9f578ab0048252f8c8f552b99f"
       ],
       0,
-      "dcd2b5622e4827aa94e05ba0e406d32d"
+      "b232cefd30e8a7cbb9e28a9790f6eb31"
     ],
     [
       "FStar.Krml.Endianness.seq_uint32_of_le",
@@ -877,7 +877,7 @@
         "well-founded-ordering-on-nat"
       ],
       0,
-      "d354ec5deb7c0ef5b51a115f9b33169c"
+      "b152f3b3c0bb32345c84448c7110f5f3"
     ],
     [
       "FStar.Krml.Endianness.le_of_seq_uint32",
@@ -913,7 +913,7 @@
         "well-founded-ordering-on-nat"
       ],
       0,
-      "c33940146f150c30f9196c05e6c0e636"
+      "c4a62ca737a1a261025509ab49c21617"
     ],
     [
       "FStar.Krml.Endianness.seq_uint32_of_be",
@@ -927,7 +927,7 @@
         "refinement_interpretation_Tm_refine_414d0a9f578ab0048252f8c8f552b99f"
       ],
       0,
-      "f8dfc239aa0718952d9118cbee3e2717"
+      "e3bf5c0f6f2ebac2b7d466194ae7d8ba"
     ],
     [
       "FStar.Krml.Endianness.seq_uint32_of_be",
@@ -967,7 +967,7 @@
         "well-founded-ordering-on-nat"
       ],
       0,
-      "c09df22dc1f18091861b62c55df400dc"
+      "e4490c7de4edd8f3a93b4bda7bdc0981"
     ],
     [
       "FStar.Krml.Endianness.be_of_seq_uint32",
@@ -1003,7 +1003,7 @@
         "well-founded-ordering-on-nat"
       ],
       0,
-      "2ed7bde40d3410cf0d4d841557b9d8d7"
+      "f19544580ded5c9285dce2e94acaf7ad"
     ],
     [
       "FStar.Krml.Endianness.seq_uint64_of_le",
@@ -1017,7 +1017,7 @@
         "refinement_interpretation_Tm_refine_414d0a9f578ab0048252f8c8f552b99f"
       ],
       0,
-      "f536249ca2b29da04fc55dcc4bb73912"
+      "f2c0b7744ce1cde2fd6bb23254c8c908"
     ],
     [
       "FStar.Krml.Endianness.seq_uint64_of_le",
@@ -1057,7 +1057,7 @@
         "well-founded-ordering-on-nat"
       ],
       0,
-      "e68d153808421bad097f0edd0c7698ec"
+      "b9da4b3517d3b7cb492e3b1901a0f399"
     ],
     [
       "FStar.Krml.Endianness.le_of_seq_uint64",
@@ -1093,7 +1093,7 @@
         "well-founded-ordering-on-nat"
       ],
       0,
-      "498cda3b2a8a18ce8f09e95407480bfa"
+      "528517f49e19204e51c11b8e19eedb38"
     ],
     [
       "FStar.Krml.Endianness.seq_uint64_of_be",
@@ -1107,7 +1107,7 @@
         "refinement_interpretation_Tm_refine_414d0a9f578ab0048252f8c8f552b99f"
       ],
       0,
-      "49322117a869e8792e448658533e0929"
+      "8fd77221a70bdb17c38d66ff92ba61f6"
     ],
     [
       "FStar.Krml.Endianness.seq_uint64_of_be",
@@ -1147,7 +1147,7 @@
         "well-founded-ordering-on-nat"
       ],
       0,
-      "1ac522d71bd6220719628e44947e5b14"
+      "af757950f476e196ce1eab793b54406d"
     ],
     [
       "FStar.Krml.Endianness.be_of_seq_uint64",
@@ -1183,7 +1183,7 @@
         "well-founded-ordering-on-nat"
       ],
       0,
-      "a121a5082222fb7ba04870bb256db178"
+      "8f917986fdf93ca8b92b66be14a5f137"
     ],
     [
       "FStar.Krml.Endianness.offset_uint32_be",
@@ -1209,7 +1209,7 @@
         "typing_FStar.UInt8.t"
       ],
       0,
-      "898418f02daa18232ae85c3555fecb69"
+      "7f95c2cc981adec00e73bf1c7f2fcb02"
     ],
     [
       "FStar.Krml.Endianness.offset_uint32_be",
@@ -1278,7 +1278,7 @@
         "well-founded-ordering-on-nat"
       ],
       0,
-      "4f0cfc69c3504e7557c7bd7ace441007"
+      "fdfb035010013b28f99c0bd657f3a847"
     ],
     [
       "FStar.Krml.Endianness.offset_uint32_le",
@@ -1304,7 +1304,7 @@
         "typing_FStar.UInt8.t"
       ],
       0,
-      "09b4f5aaa736b8ee323f850e67b66f85"
+      "f680127b37e4228c5207e2861bafdaee"
     ],
     [
       "FStar.Krml.Endianness.offset_uint32_le",
@@ -1371,7 +1371,7 @@
         "well-founded-ordering-on-nat"
       ],
       0,
-      "fbc8d76c6d9c8ceb16c9484b59ed1cd3"
+      "a5f19e643d9d2cafe074a342522f1744"
     ],
     [
       "FStar.Krml.Endianness.offset_uint64_be",
@@ -1397,7 +1397,7 @@
         "typing_FStar.UInt8.t"
       ],
       0,
-      "f06fdec0d1608ea7c9c63fdc94bef5d0"
+      "5375e75d6754da35fd19cbed90221a51"
     ],
     [
       "FStar.Krml.Endianness.offset_uint64_be",
@@ -1466,7 +1466,7 @@
         "well-founded-ordering-on-nat"
       ],
       0,
-      "2caf256baf2f4bcb34c4cd22dd0e22ec"
+      "c957eb8600023a4e2516906c0c6a9e07"
     ],
     [
       "FStar.Krml.Endianness.offset_uint64_le",
@@ -1492,7 +1492,7 @@
         "typing_FStar.UInt8.t"
       ],
       0,
-      "9ef0ff7e8916ce064e9bda3b4e7fa6f8"
+      "111190f155550e11680d5efa8b91acee"
     ],
     [
       "FStar.Krml.Endianness.offset_uint64_le",
@@ -1564,7 +1564,7 @@
         "well-founded-ordering-on-nat"
       ],
       0,
-      "9cdc4e73983d79f8459198dee4d88b08"
+      "2b86748ca2f64235408dfbe3dd2e87ef"
     ],
     [
       "FStar.Krml.Endianness.tail_cons",
@@ -1598,7 +1598,7 @@
         "typing_FStar.Seq.Properties.tail"
       ],
       0,
-      "455b6404266c76a38dff5796dd2ebdb2"
+      "359bea35e5f32ce86cf2d04a96cc4563"
     ],
     [
       "FStar.Krml.Endianness.be_of_seq_uint32_append",
@@ -1672,7 +1672,7 @@
         "well-founded-ordering-on-nat"
       ],
       0,
-      "a5665a3f705ac9ac790a27755fe59318"
+      "1be9c7b484685da9e475e36eb4241bf3"
     ],
     [
       "FStar.Krml.Endianness.be_of_seq_uint32_base",
@@ -1728,7 +1728,7 @@
         "typing_FStar.UInt8.t"
       ],
       0,
-      "806eab51bf9c66cbf3b04a04d4e12dd4"
+      "7f48af32df5d68c2e061a443cc3e3b99"
     ],
     [
       "FStar.Krml.Endianness.le_of_seq_uint32_append",
@@ -1791,7 +1791,7 @@
         "typing_FStar.UInt8.t", "well-founded-ordering-on-nat"
       ],
       0,
-      "f42e0eccb8a3af26118f7c62c9e02cc2"
+      "b9d88f93e58c95522bff2bdf3ca36019"
     ],
     [
       "FStar.Krml.Endianness.le_of_seq_uint32_base",
@@ -1847,7 +1847,7 @@
         "typing_FStar.UInt8.t"
       ],
       0,
-      "40f44c3aedf01385e9900a02f3de9b66"
+      "0dd44bcd5b0949454a36f47c41813735"
     ],
     [
       "FStar.Krml.Endianness.be_of_seq_uint64_append",
@@ -1928,7 +1928,7 @@
         "well-founded-ordering-on-nat"
       ],
       0,
-      "7112245193c963203164ebd195ef3b60"
+      "bbef72c89383e8e248d12cf14c4044ed"
     ],
     [
       "FStar.Krml.Endianness.be_of_seq_uint64_base",
@@ -1986,7 +1986,7 @@
         "typing_FStar.UInt8.t", "typing_Prims.pow2"
       ],
       0,
-      "a1d178b8fe1f8529920eae8587bc0cd9"
+      "26b07999604ab979d7dfc937958b9706"
     ],
     [
       "FStar.Krml.Endianness.seq_uint32_of_be_be_of_seq_uint32",
@@ -1998,7 +1998,7 @@
         "refinement_interpretation_Tm_refine_a84773c2eb377e624aba800b71ec3ba0"
       ],
       0,
-      "0e8247479e1e7876dc2693ebb21e1212"
+      "06a53d3319b30f8d642b788a2b406c3b"
     ],
     [
       "FStar.Krml.Endianness.seq_uint32_of_be_be_of_seq_uint32",
@@ -2074,7 +2074,7 @@
         "typing_FStar.UInt8.t", "well-founded-ordering-on-nat"
       ],
       0,
-      "bd322094634b4ac623482f9d23960aad"
+      "6a2cc46c0e8c0908a86fcab57092d38f"
     ],
     [
       "FStar.Krml.Endianness.be_of_seq_uint32_seq_uint32_of_be",
@@ -2086,7 +2086,7 @@
         "refinement_interpretation_Tm_refine_4239cb7a019da00e7afc3bc55aa05dd7"
       ],
       0,
-      "b7247568bda96659bd5f9b10c3243fbc"
+      "d7bac1e76ec2207bceaa141c591878c7"
     ],
     [
       "FStar.Krml.Endianness.be_of_seq_uint32_seq_uint32_of_be",
@@ -2164,7 +2164,7 @@
         "typing_FStar.UInt8.v", "well-founded-ordering-on-nat"
       ],
       0,
-      "72090d17df2827554ea6de9f60eaf142"
+      "2e3953f0874fffc0498009bf70915944"
     ],
     [
       "FStar.Krml.Endianness.slice_seq_uint32_of_be",
@@ -2214,7 +2214,7 @@
         "typing_FStar.UInt32.t", "typing_FStar.UInt8.t"
       ],
       0,
-      "51528745ee6a649d4c398f3b6997ea3e"
+      "397ee91d7a3e37131285ba0715bb8209"
     ],
     [
       "FStar.Krml.Endianness.be_of_seq_uint32_slice",
@@ -2266,7 +2266,7 @@
         "typing_FStar.UInt8.t"
       ],
       0,
-      "17f8416330242e0511ef39dff18f95c2"
+      "c03b5584d1cac6a11cba26f397049e10"
     ]
   ]
 ]

--- a/krmllib/hints/LowStar.Lib.AssocList.fst.hints
+++ b/krmllib/hints/LowStar.Lib.AssocList.fst.hints
@@ -8,7 +8,7 @@
       0,
       [ "@query", "equation_LowStar.Lib.AssocList.invariant" ],
       0,
-      "5bed0e5e0b89e9aba7b0365d5a58febd"
+      "3bd893c42f0d92d6b4316e134642d512"
     ],
     [
       "LowStar.Lib.AssocList.frame",
@@ -73,7 +73,7 @@
         "typing_LowStar.Monotonic.Buffer.loc_union"
       ],
       0,
-      "63be16e611e791299e11f1834a208a26"
+      "145ae528ddc06f586312f1278e50ad31"
     ],
     [
       "LowStar.Lib.AssocList.footprint_in_r",
@@ -86,7 +86,7 @@
         "refinement_interpretation_Tm_refine_2de20c066034c13bf76e9c0b94f4806c"
       ],
       0,
-      "4ce393db617a3405438e9fabd8deafe0"
+      "9008f954c97d0c6fe8c2e7b630c21bed"
     ],
     [
       "LowStar.Lib.AssocList.footprint_in_r",
@@ -102,7 +102,7 @@
         "fuel_guarded_inversion_LowStar.Lib.LinkedList2.t"
       ],
       0,
-      "5d87a8ec501be3efba500a012a911089"
+      "8382585aa2ce8ae567c0a7b9d3330f06"
     ],
     [
       "LowStar.Lib.AssocList.create_in",
@@ -136,7 +136,7 @@
         "typing_Tm_abs_05dbb0bdbe4a61cef8fed1432b1b98e9"
       ],
       0,
-      "30be9d696a3bd7f61b5c3696c6f16a5e"
+      "4d6a9f5a4319e2002d42da27f6456887"
     ],
     [
       "LowStar.Lib.AssocList.find_",
@@ -145,7 +145,7 @@
       0,
       [ "@query" ],
       0,
-      "0a1cff78be9e1d914cc605aa8a3a08b7"
+      "9f3bdd72edb224398bac39985674a0ad"
     ],
     [
       "LowStar.Lib.AssocList.find_",
@@ -230,7 +230,7 @@
         "typing_Tm_abs_05dbb0bdbe4a61cef8fed1432b1b98e9"
       ],
       0,
-      "d278436397e87e44f7d791a6eb674026"
+      "f5695de136563ff6484759d76adc9e7a"
     ],
     [
       "LowStar.Lib.AssocList.find",
@@ -248,7 +248,7 @@
         "refinement_interpretation_Tm_refine_b582da5b18980dd549f83acfd27b47df"
       ],
       0,
-      "ae0f7c08aaf74b696232c0fa45707bfe"
+      "febf04e83351d26023d259429bc89b06"
     ],
     [
       "LowStar.Lib.AssocList.add",
@@ -344,7 +344,7 @@
         "typing_Tm_abs_05dbb0bdbe4a61cef8fed1432b1b98e9"
       ],
       0,
-      "14e82bdea74256cc2c8929b4b52677e0"
+      "87e2f4e016cfbe8cbb065b5ea0153030"
     ],
     [
       "LowStar.Lib.AssocList.remove_all_",
@@ -356,7 +356,7 @@
         "refinement_interpretation_Tm_refine_666cbc765faa85ecb6368ba0ccf434cd"
       ],
       0,
-      "1ee77b48923b776a1a874bfb528ad6be"
+      "c5bf6362122f8b931fd59290e3448e93"
     ],
     [
       "LowStar.Lib.AssocList.remove_all_",
@@ -485,7 +485,7 @@
         "typing_Tm_abs_05dbb0bdbe4a61cef8fed1432b1b98e9"
       ],
       0,
-      "7ce367b6efb6804a5b61c1abb72d7837"
+      "a57f8b8f082bf47b885bb238f4d3bddc"
     ],
     [
       "LowStar.Lib.AssocList.remove_all",
@@ -597,7 +597,7 @@
         "typing_LowStar.Monotonic.Buffer.loc_regions"
       ],
       0,
-      "f859f91316a241989c6752bca5ca864c"
+      "614a0ebc88ffd477e5d4a5b288d4367f"
     ],
     [
       "LowStar.Lib.AssocList.clear",
@@ -684,7 +684,7 @@
         "typing_Tm_abs_05dbb0bdbe4a61cef8fed1432b1b98e9"
       ],
       0,
-      "f81e0882d454245981cc910c257d6ec5"
+      "e6b52ed1c6195d643e6adc42e1c2367c"
     ],
     [
       "LowStar.Lib.AssocList.free",
@@ -756,7 +756,7 @@
         "typing_LowStar.Monotonic.Buffer.loc_union"
       ],
       0,
-      "feb1c490856dfc0b6052f629f539cde9"
+      "0f9d66caa0ae8d4f6cb208b601e1ef8b"
     ]
   ]
 ]

--- a/krmllib/hints/LowStar.Lib.LinkedList.fst.hints
+++ b/krmllib/hints/LowStar.Lib.LinkedList.fst.hints
@@ -14,7 +14,7 @@
         "projection_inverse_BoxInt_proj_0", "subterm_ordering_Prims.Cons"
       ],
       0,
-      "786d0d84add5f7d88fc77445dba28aa4"
+      "12030eee4eb479c13a4f81926e6f0dee"
     ],
     [
       "LowStar.Lib.LinkedList.cells",
@@ -50,7 +50,7 @@
         "typing_LowStar.Monotonic.Buffer.g_is_null"
       ],
       0,
-      "4b26476a7cc0c27210c942a546dd7ec8"
+      "95fd79139b585493d9a0f6904d1cf2fa"
     ],
     [
       "LowStar.Lib.LinkedList.same_cells_same_pointer",
@@ -86,7 +86,7 @@
         "unit_typing"
       ],
       0,
-      "3d0b4b967f2a5415448c90efa8e1c1a0"
+      "2de4c390021ead356d877cf2ecbedf99"
     ],
     [
       "LowStar.Lib.LinkedList.footprint",
@@ -118,7 +118,7 @@
         "subterm_ordering_Prims.Cons"
       ],
       0,
-      "a3ba6e7555668be6162776864b542604"
+      "b44012daf9070683c4a99d786d2dbdcf"
     ],
     [
       "LowStar.Lib.LinkedList.cells_pairwise_disjoint",
@@ -152,7 +152,7 @@
         "subterm_ordering_Prims.Cons"
       ],
       0,
-      "32c02313d92c21eb44fb178ce5ecc00e"
+      "c5a463e598164620244d4ec3c354bd3f"
     ],
     [
       "LowStar.Lib.LinkedList.cells_live_freeable",
@@ -186,7 +186,7 @@
         "subterm_ordering_Prims.Cons"
       ],
       0,
-      "0145dd17b5dc62f25d6c659466cf8b18"
+      "487b6c873dc212abeec56bf64b0f367d"
     ],
     [
       "LowStar.Lib.LinkedList.invariant",
@@ -195,7 +195,7 @@
       1,
       [ "@query", "equation_Prims.logical" ],
       0,
-      "6d4fecc1f2b4473454e3280155217796"
+      "c3f99907640dfcc0fe5ca9906c30b910"
     ],
     [
       "LowStar.Lib.LinkedList.invariant_loc_in_footprint",
@@ -209,7 +209,7 @@
         "refinement_interpretation_Tm_refine_2de20c066034c13bf76e9c0b94f4806c"
       ],
       0,
-      "8ca9ff54be1afcf499891e28b02a91ee"
+      "9d09544ab19f3a608a0fdb585a904ead"
     ],
     [
       "LowStar.Lib.LinkedList.invariant_loc_in_footprint",
@@ -273,7 +273,7 @@
         "typing_LowStar.Monotonic.Buffer.loc_not_unused_in"
       ],
       0,
-      "880c0f2495a66e225cb86a35b2693e85"
+      "70693f30f32110094a53cb2cc18e3718"
     ],
     [
       "LowStar.Lib.LinkedList.frame",
@@ -285,7 +285,7 @@
         "refinement_interpretation_Tm_refine_9dfd5ec664d04b1adbe6909975d3119f"
       ],
       0,
-      "2fc44433e5eab904f20234a46632c256"
+      "6fc8d4e389cecfacb730b688edb0ec72"
     ],
     [
       "LowStar.Lib.LinkedList.frame",
@@ -376,7 +376,7 @@
         "typing_LowStar.Monotonic.Buffer.loc_buffer"
       ],
       0,
-      "9491a8d4978c4931c46c20ba269d0560"
+      "f42ff37bc2072df03eb04aa73dfda4f0"
     ],
     [
       "LowStar.Lib.LinkedList.length_functional",
@@ -418,7 +418,7 @@
         "typing_LowStar.Buffer.trivial_preorder"
       ],
       0,
-      "ab95666c63f67f63386d3715e4c285c6"
+      "279bc56db11d74d58216f4442742a310"
     ],
     [
       "LowStar.Lib.LinkedList.gmap",
@@ -433,7 +433,7 @@
         "projection_inverse_BoxBool_proj_0", "subterm_ordering_Prims.Cons"
       ],
       0,
-      "e7bf781cd18c737d786c8577cd2516a6"
+      "25fa350e97f1b58cdba711ff964f2259"
     ],
     [
       "LowStar.Lib.LinkedList.gfold_right",
@@ -448,7 +448,7 @@
         "projection_inverse_BoxBool_proj_0", "subterm_ordering_Prims.Cons"
       ],
       0,
-      "2b1431e4c311d45cadfe9b3043e99309"
+      "b55011b0187a309f322bd816edc60976"
     ],
     [
       "LowStar.Lib.LinkedList.deref_cells_is_v",
@@ -460,7 +460,7 @@
         "refinement_interpretation_Tm_refine_2cdb1d22d11cea5954bcab0f89d645ec"
       ],
       0,
-      "28c1ea8a87c92c8b8e4efa058ea600da"
+      "17749c9d77697ef0492eb5b041eb1e71"
     ],
     [
       "LowStar.Lib.LinkedList.deref_cells_is_v",
@@ -524,7 +524,7 @@
         "typing_LowStar.Lib.LinkedList.cells"
       ],
       0,
-      "63e2587f1461884074d9d5f0d05027b2"
+      "b27e135e234fcb086c5259debb7d54ea"
     ],
     [
       "LowStar.Lib.LinkedList.footprint_via_cells_is_footprint",
@@ -541,7 +541,7 @@
         "refinement_interpretation_Tm_refine_414d0a9f578ab0048252f8c8f552b99f"
       ],
       0,
-      "a53e670c777e9d2bdd19c19c45642eb3"
+      "e9d10ec25ac8ee72eca76fd73ae503b8"
     ],
     [
       "LowStar.Lib.LinkedList.footprint_via_cells_is_footprint",
@@ -629,7 +629,7 @@
         "typing_Tm_abs_3d46d953d7df849c026fcef6c4941216"
       ],
       0,
-      "72d42568aef1d5b096c6258c5f48a3f1"
+      "df0831e44982cb0e21de81f630e977f1"
     ],
     [
       "LowStar.Lib.LinkedList.push",
@@ -641,7 +641,7 @@
         "refinement_interpretation_Tm_refine_2e3312cd41d7f5efbbbae3b2eeef697e"
       ],
       0,
-      "f5e93aaf2be798ec8e283126ec649c26"
+      "ec379ad22cac976e5c80784e4b68d320"
     ],
     [
       "LowStar.Lib.LinkedList.push",
@@ -773,7 +773,7 @@
         "typing_LowStar.Monotonic.Buffer.loc_unused_in"
       ],
       0,
-      "a2ff50f59423d70f9403e652512607d2"
+      "fb3bc3426b16a8bcc57e65269757b227"
     ],
     [
       "LowStar.Lib.LinkedList.pop",
@@ -804,7 +804,7 @@
         "typing_LowStar.Buffer.trivial_preorder"
       ],
       0,
-      "77a5e43abd69ca162e27898fb17822be"
+      "910b9c419b14b309ab5f2fe900ec12ef"
     ],
     [
       "LowStar.Lib.LinkedList.pop",
@@ -913,7 +913,7 @@
         "typing_LowStar.Monotonic.Buffer.loc_union"
       ],
       0,
-      "be08458ae7079e0232073271419f9d9c"
+      "198eb207ed0297488d1dfb859067a94c"
     ],
     [
       "LowStar.Lib.LinkedList.free_",
@@ -925,7 +925,7 @@
         "refinement_interpretation_Tm_refine_994dd8cb51034b7a0776f9bb28ca6f71"
       ],
       0,
-      "4d34373633cace46648cc8af61ff117d"
+      "24de58861c663804ee16d872f3cc6e18"
     ],
     [
       "LowStar.Lib.LinkedList.free_",
@@ -1015,7 +1015,7 @@
         "typing_LowStar.Monotonic.Buffer.loc_buffer"
       ],
       0,
-      "3d8edee46957657e40ff7b84da470381"
+      "f63b9dd8bf81620c5982dfbf563b4901"
     ],
     [
       "LowStar.Lib.LinkedList.free",
@@ -1027,7 +1027,7 @@
         "refinement_interpretation_Tm_refine_baa6a0434e5b51218cc000deadc8f6bc"
       ],
       0,
-      "13b19f52a257808f2f2026600ed38dba"
+      "f776cc553df41b9a21abc201a243a5a6"
     ],
     [
       "LowStar.Lib.LinkedList.free",
@@ -1114,7 +1114,7 @@
         "typing_LowStar.Monotonic.Buffer.mnull"
       ],
       0,
-      "a1b41fb73c6c0391884e2d5c5703e367"
+      "17f7542c71dfe52603f4647745e9d6b4"
     ],
     [
       "LowStar.Lib.LinkedList.length",
@@ -1123,7 +1123,7 @@
       1,
       [ "@query" ],
       0,
-      "c88632e3ed6c4a1ab9a111bf2c06198f"
+      "507f4b4ce5d9b8a44e48cf95b2f972af"
     ],
     [
       "LowStar.Lib.LinkedList.length",
@@ -1188,7 +1188,7 @@
         "typing_LowStar.Monotonic.Buffer.len"
       ],
       0,
-      "c97a1761bf4be2fb184d03cff56738b5"
+      "77ea98d316f93208b9a963b67dea24e7"
     ],
     [
       "LowStar.Lib.LinkedList.test",
@@ -1325,7 +1325,7 @@
         "typing_LowStar.Monotonic.Buffer.mnull"
       ],
       0,
-      "c2a027cef0d75be85539d648e8dd3c2d"
+      "652c8358ea37a5505d167a35db6a19c9"
     ]
   ]
 ]

--- a/krmllib/hints/LowStar.Lib.LinkedList2.fst.hints
+++ b/krmllib/hints/LowStar.Lib.LinkedList2.fst.hints
@@ -17,7 +17,7 @@
         "typing_LowStar.Lib.LinkedList2.__proj__Mkt__item__r"
       ],
       0,
-      "5c2feeeb4f796ef93cdf6c68a753e9ad"
+      "591f4da5d25eaaafc351c31948ca7c26"
     ],
     [
       "LowStar.Lib.LinkedList2.footprint",
@@ -29,7 +29,7 @@
         "l_and-interp"
       ],
       0,
-      "04260cc65020a7dc49e6a64495fb9ac4"
+      "1ada1ba29beed438598de1e25188569d"
     ],
     [
       "LowStar.Lib.LinkedList2.cells",
@@ -41,7 +41,7 @@
         "l_and-interp"
       ],
       0,
-      "1d0ef700de3364f0ae39c9af5161f5e6"
+      "1ba73b62f827dc9fe04b9bbadc63f7b8"
     ],
     [
       "LowStar.Lib.LinkedList2.footprint_in_r",
@@ -111,7 +111,7 @@
         "typing_LowStar.Monotonic.Buffer.loc_union"
       ],
       0,
-      "190163a56621c3718e77620517f25189"
+      "245b60ef5048e1aa65b01fb05bcd6f5b"
     ],
     [
       "LowStar.Lib.LinkedList2.frame_footprint",
@@ -123,7 +123,7 @@
         "refinement_interpretation_Tm_refine_09ad67b9d90ed7b17ddf31c45c68b636"
       ],
       0,
-      "74b52a4a21ee36beb38efc088b4579ae"
+      "550958aac05af5f78a869c2a93e9348d"
     ],
     [
       "LowStar.Lib.LinkedList2.frame_footprint",
@@ -181,7 +181,7 @@
         "typing_LowStar.Monotonic.Buffer.loc_union"
       ],
       0,
-      "f77ca91aa043147809c223fb746c2cfd"
+      "644c2bb0783780f4d0be534a7c3d0205"
     ],
     [
       "LowStar.Lib.LinkedList2.frame_region",
@@ -193,7 +193,7 @@
         "refinement_interpretation_Tm_refine_76a8d76aec5fe95490cf6c28517bab40"
       ],
       0,
-      "0fab12187cbfc4958b78bcbafc358b10"
+      "7ce0f017c076fc60b325eed5ed3fbdc2"
     ],
     [
       "LowStar.Lib.LinkedList2.frame_region",
@@ -253,7 +253,7 @@
         "typing_LowStar.Monotonic.Buffer.loc_union"
       ],
       0,
-      "c3030c1919a17f8d8a027869a4194dc4"
+      "732617492b85e2b0a771e2b2ad198427"
     ],
     [
       "LowStar.Lib.LinkedList2.create_in",
@@ -262,7 +262,7 @@
       0,
       [ "@query" ],
       0,
-      "656a0d206ab86829f60852dc398ea341"
+      "f4e729b5bdef6dcaac221ea4ceefc088"
     ],
     [
       "LowStar.Lib.LinkedList2.create_in",
@@ -392,7 +392,7 @@
         "typing_LowStar.Monotonic.Buffer.mnull"
       ],
       0,
-      "9d61ce9d39fde10bebf8ab9098ba650c"
+      "5b852cfe910811f40ebf637a8a6bee04"
     ],
     [
       "LowStar.Lib.LinkedList2.push",
@@ -404,7 +404,7 @@
         "refinement_interpretation_Tm_refine_89e26769e50512fd6a99e61c0fe00f0a"
       ],
       0,
-      "6529071acc46d7d4eee9b21e830fa804"
+      "760dac94c3acbfd9cd2cb46d880b6042"
     ],
     [
       "LowStar.Lib.LinkedList2.push",
@@ -521,7 +521,7 @@
         "typing_LowStar.Monotonic.Buffer.loc_union"
       ],
       0,
-      "dc0abf92862769e30c36f73c85738a32"
+      "a327a9b4f5a38aeb740b82c43dc3068b"
     ],
     [
       "LowStar.Lib.LinkedList2.pop",
@@ -567,7 +567,7 @@
         "typing_LowStar.Monotonic.Buffer.get"
       ],
       0,
-      "1227823d57f516709c8dfb18f0e31da7"
+      "7623876db7a4db66906f60584c749b3a"
     ],
     [
       "LowStar.Lib.LinkedList2.pop",
@@ -689,7 +689,7 @@
         "typing_Prims.uu___is_Cons"
       ],
       0,
-      "1c5655d4a573f73b942de150e08a2ad2"
+      "080abaff7af32b4f8009295deaf2df14"
     ],
     [
       "LowStar.Lib.LinkedList2.maybe_pop",
@@ -738,7 +738,7 @@
         "typing_LowStar.Monotonic.Buffer.get"
       ],
       0,
-      "1a6446cee2199b79b6585ed0fa20c1f4"
+      "2633609e259c98254923e2439adf1dc8"
     ],
     [
       "LowStar.Lib.LinkedList2.maybe_pop",
@@ -883,7 +883,7 @@
         "typing_LowStar.Monotonic.Buffer.loc_union"
       ],
       0,
-      "6a5048d30e0097eb827524ec09513994"
+      "dcbeb7d3d26ea214b38c2accb5173869"
     ],
     [
       "LowStar.Lib.LinkedList2.clear",
@@ -895,7 +895,7 @@
         "refinement_interpretation_Tm_refine_89e26769e50512fd6a99e61c0fe00f0a"
       ],
       0,
-      "7ad121925fab191d3962704e529c41ac"
+      "8a3be00fd16e07368072468268fb3dcf"
     ],
     [
       "LowStar.Lib.LinkedList2.clear",
@@ -1005,7 +1005,7 @@
         "typing_LowStar.Monotonic.Buffer.loc_union"
       ],
       0,
-      "36b3e2e883e49e39ee48afdddd68b877"
+      "dd2441c1704640647f415e9d8eaad847"
     ],
     [
       "LowStar.Lib.LinkedList2.free",
@@ -1017,7 +1017,7 @@
         "refinement_interpretation_Tm_refine_89e26769e50512fd6a99e61c0fe00f0a"
       ],
       0,
-      "458d939dc35bfc17357e7d8667b90020"
+      "74ad74126275b98361a73700301b7ab9"
     ],
     [
       "LowStar.Lib.LinkedList2.free",
@@ -1096,7 +1096,7 @@
         "typing_LowStar.Monotonic.Buffer.loc_union"
       ],
       0,
-      "9652d476243094df71a7444d824ed01a"
+      "c47ac6c3c4eb0bdb829497b84413a4d9"
     ],
     [
       "LowStar.Lib.LinkedList2.test",
@@ -1232,7 +1232,7 @@
         "typing_LowStar.Monotonic.Buffer.loc_unused_in"
       ],
       0,
-      "8b8ee534bb972ab09d5a6f175e9df7f7"
+      "420ea590575db8c5bda6095570c9c2ac"
     ]
   ]
 ]

--- a/krmllib/hints/Spec.Loops.fst.hints
+++ b/krmllib/hints/Spec.Loops.fst.hints
@@ -13,7 +13,7 @@
         "refinement_interpretation_Tm_refine_414d0a9f578ab0048252f8c8f552b99f"
       ],
       0,
-      "4d7009a8fe8336b4cbe202fd0a16e459"
+      "b1dbbef4314ac9511f7cffbdd7e1f350"
     ],
     [
       "Spec.Loops.seq_map",
@@ -27,7 +27,7 @@
         "refinement_interpretation_Tm_refine_414d0a9f578ab0048252f8c8f552b99f"
       ],
       0,
-      "3448e9dc7f6ff70e5ecec137aae7cafe"
+      "ec909af3c26b9200cc0ea14500a23a41"
     ],
     [
       "Spec.Loops.seq_map",
@@ -73,7 +73,7 @@
         "well-founded-ordering-on-nat"
       ],
       0,
-      "4f41827bceeb4399228040944f3299d7"
+      "121095c676cf7ed6c9dd5d885e6da8fa"
     ],
     [
       "Spec.Loops.seq_map2",
@@ -88,7 +88,7 @@
         "refinement_interpretation_Tm_refine_414d0a9f578ab0048252f8c8f552b99f"
       ],
       0,
-      "087ee3a491a20fd277ff5407ae1ab264"
+      "dfa1ee56df293d44ecfb7ff49238ccda"
     ],
     [
       "Spec.Loops.seq_map2",
@@ -103,7 +103,7 @@
         "refinement_interpretation_Tm_refine_aab03343de950d77c26ad9d98d2757b8"
       ],
       0,
-      "ac7752214fc7fba23bf98ad2a26b3a74"
+      "cb33830eda9390c71ead43ff7014a502"
     ],
     [
       "Spec.Loops.seq_map2",
@@ -152,7 +152,7 @@
         "well-founded-ordering-on-nat"
       ],
       0,
-      "7a6f9619dfe01f786239c45ecf4da518"
+      "3ec4179684cfcdc9ff9aaded806cbeb7"
     ],
     [
       "Spec.Loops.repeat",
@@ -169,7 +169,7 @@
         "well-founded-ordering-on-nat"
       ],
       0,
-      "1411329b67e5715c55ae52cf8af58416"
+      "d2473cb0a4359aac4ea7edb6f05ec127"
     ],
     [
       "Spec.Loops.repeat_induction",
@@ -182,7 +182,7 @@
         "refinement_interpretation_Tm_refine_afd51579b90d50ea23e03b743a1fa001"
       ],
       0,
-      "f13b8f6b64aeb79b7d264928efefbeac"
+      "3eadb5fc65b718d2e8402626f1707037"
     ],
     [
       "Spec.Loops.repeat_induction",
@@ -195,7 +195,7 @@
         "refinement_interpretation_Tm_refine_afd51579b90d50ea23e03b743a1fa001"
       ],
       0,
-      "116afe77cfb6c57a69c5eefbab2f782d"
+      "f2d4ae3c4639b0a30df560f9e50c1096"
     ],
     [
       "Spec.Loops.repeat_induction",
@@ -224,7 +224,7 @@
         "typing_Spec.Loops.repeat", "well-founded-ordering-on-nat"
       ],
       0,
-      "c57b93874e008a3de4d19428b498e649"
+      "cac05b373d0b61ef8db1303313e6c527"
     ],
     [
       "Spec.Loops.repeat_base",
@@ -247,7 +247,7 @@
         "refinement_interpretation_Tm_refine_f52d524f7d227b5c40129c018d34fe1d"
       ],
       0,
-      "fca933178024c3ab4c6bc9c93b1a35ff"
+      "2cd280e984c269a3f1768dcdda5d4022"
     ],
     [
       "Spec.Loops.repeat_range",
@@ -273,7 +273,7 @@
         "well-founded-ordering-on-nat"
       ],
       0,
-      "9a92661c810b1ddd668f8135bf187906"
+      "b3a2320d81cdbbf4a3a17150feafe6a8"
     ],
     [
       "Spec.Loops.repeat_range_base",
@@ -282,7 +282,7 @@
       1,
       [ "@query" ],
       0,
-      "5527f4370262c2f0636716dcd4b4d06b"
+      "723c171a51b21b9fe632a5fb9b30fb41"
     ],
     [
       "Spec.Loops.repeat_range_base",
@@ -299,7 +299,7 @@
         "refinement_interpretation_Tm_refine_571d9f74016be5357787170b42ecf913"
       ],
       0,
-      "5ecb3bb17d1aaee1df31b811dbf37c1b"
+      "d86f371bc7e2fa2e440e63e38aead0e5"
     ],
     [
       "Spec.Loops.repeat_range_induction",
@@ -314,7 +314,7 @@
         "refinement_interpretation_Tm_refine_8233d76b57e95451540fc312b717fa79"
       ],
       0,
-      "63f6bb39b00ab6bf6fd968c4c9e0b173"
+      "e5749eed28e554d0ab86ed217b8f3873"
     ],
     [
       "Spec.Loops.repeat_range_induction",
@@ -329,7 +329,7 @@
         "refinement_interpretation_Tm_refine_8233d76b57e95451540fc312b717fa79"
       ],
       0,
-      "43620226309a0f7e19e1cd217ae6be73"
+      "379d1c6282bd7a8d997a587371a89c98"
     ],
     [
       "Spec.Loops.repeat_range_induction",
@@ -363,7 +363,7 @@
         "typing_Spec.Loops.repeat_range", "well-founded-ordering-on-nat"
       ],
       0,
-      "6d1877fc3cc1064fccc431cc4aaaa565"
+      "be89f62086bd1eab2c9e10a02985e7fa"
     ]
   ]
 ]

--- a/krmllib/hints/TestLib.fsti.hints
+++ b/krmllib/hints/TestLib.fsti.hints
@@ -8,7 +8,7 @@
       1,
       [ "@query" ],
       0,
-      "4f9f918a6e082d7db9d4092ad0ff6b81"
+      "45b6350ba401f6a379a17e5e6fca46fa"
     ],
     [
       "TestLib.unsafe_malloc",
@@ -17,7 +17,7 @@
       1,
       [ "@query" ],
       0,
-      "97bccd80df3f5de56d2fed4211c8b91e"
+      "40dbfc22afca7d5851a2b96d20b56b20"
     ]
   ]
 ]

--- a/krmllib/hints/WasmSupport.fst.hints
+++ b/krmllib/hints/WasmSupport.fst.hints
@@ -20,7 +20,7 @@
         "typing_FStar.Monotonic.HyperStack.get_hmap"
       ],
       0,
-      "8d292105d74e66d80a7423f7012e0251"
+      "0d0cc2b1e9de310046977a2de5895749"
     ],
     [
       "WasmSupport.betole64",
@@ -29,7 +29,7 @@
       1,
       [ "@query" ],
       0,
-      "952234f1508ee242dd93b253edf52bd9"
+      "0efe89ea8e15044e4d912391be2d2609"
     ],
     [
       "WasmSupport.memzero",
@@ -63,7 +63,7 @@
         "typing_LowStar.Monotonic.Buffer.loc_buffer"
       ],
       0,
-      "43fa8cb84d23b9999e0c61a52f45637d"
+      "ac8be1e4ac426e14e69408fa2ceefd52"
     ]
   ]
 ]

--- a/src/Ast.ml
+++ b/src/Ast.ml
@@ -27,6 +27,7 @@ and lifetime = Common.lifetime [@ opaque]
 and constant = K.t [@ opaque]
 and ident = string [@ opaque]
 and poly_comp = K.poly_comp [@ opaque]
+and forward_kind = Common.forward_kind [@ opaque]
 and lident = ident list * ident [@ opaque]
   [@@deriving show,
     visitors { variety = "iter"; name = "iter_misc"; polymorphic = true },
@@ -72,7 +73,7 @@ and type_def =
   | Variant of branches_t
   | Enum of lident list
   | Union of (ident * typ) list
-  | Forward
+  | Forward of forward_kind
 
 and fields_t_opt =
   (ident option * (typ * bool)) list

--- a/src/AstToCStar.ml
+++ b/src/AstToCStar.ml
@@ -755,8 +755,8 @@ and mk_declaration m env d: (CStar.decl * _) option =
         in
         Some (CStar.External (name, add_cc (mk_type env t), flags, pp), [])
 
-  | DType (name, flags, _, Forward) ->
-      Some (CStar.TypeForward (name, flags), [ GlobalNames.to_c_name m name ])
+  | DType (name, flags, _, Forward k) ->
+      Some (CStar.TypeForward (name, flags, k), [ GlobalNames.to_c_name m name ])
 
   | DType (name, flags, 0, def) ->
       Some (CStar.Type (name, mk_type_def env def, flags), [ GlobalNames.to_c_name m name ] )
@@ -787,7 +787,7 @@ and mk_type_def env d: CStar.typ =
         f, mk_type env t
       ) fields)
 
-  | Forward ->
+  | Forward _ ->
       failwith "impossible, handled by mk_declaration"
 
 

--- a/src/Builtin.ml
+++ b/src/Builtin.ml
@@ -364,7 +364,7 @@ let make_abstract_function_or_global = function
         None
   | DType (name, flags, _, _) when List.mem Common.AbstractStruct flags ->
       (* We assume the module doesn't lie and the CAbstractStruct will type-check in C. *)
-      Some (DType (name, List.filter ((<>) Common.AbstractStruct) flags, 0, Forward))
+      Some (DType (name, List.filter ((<>) Common.AbstractStruct) flags, 0, Forward FStruct))
   | d ->
       Some d
 

--- a/src/C11.ml
+++ b/src/C11.ml
@@ -13,7 +13,7 @@ type type_spec =
   | Struct of ident option * declaration list option
       (** Note: the option allows for zero-sized structs (GCC's C, C++) but as
        * of 2017/05/14 we never generate these. *)
-  | Union of ident option * declaration list
+  | Union of ident option * declaration list option
   | Enum of ident option * ident list
     (** not encoding all the invariants here *)
   [@@deriving show]

--- a/src/CStar.ml
+++ b/src/CStar.ml
@@ -16,7 +16,7 @@ and decl =
      * as a macro. *)
   | Function of calling_convention option * flag list * typ * lident * binder list * block
   | Type of lident * typ * flag list
-  | TypeForward of lident * flag list
+  | TypeForward of lident * flag list * forward_kind
   | External of lident * typ * flag list * string list
     (** String list for pretty-printing the names of the arguments. *)
 
@@ -128,7 +128,7 @@ let lid_of_decl (d: decl): lident =
   | Global (id, _, _, _, _)
   | Function (_, _, _, id, _, _)
   | Type (id, _, _)
-  | TypeForward (id, _)
+  | TypeForward (id, _, _)
   | External (id, _, _, _) ->
       id
 
@@ -137,7 +137,7 @@ let flags_of_decl (d: decl): Common.flag list =
   | Global (_, _, flags, _, _)
   | Function (_, flags, _, _, _, _)
   | Type (_, _, flags)
-  | TypeForward (_, flags)
+  | TypeForward (_, flags, _)
   | External (_, _, flags, _) ->
       flags
 

--- a/src/CStarToC11.ml
+++ b/src/CStarToC11.ml
@@ -257,15 +257,18 @@ let rec mk_spec_and_decl m name qs (t: typ) (k: C.declarator -> C.declarator):
   | Struct fields ->
       qs, Struct (None, mk_fields m fields), k (Ident name)
   | Union fields ->
-      qs, Union (None, List.map (fun (name, typ) ->
-        let qs, spec, decl = mk_spec_and_decl m name [] typ (fun d -> d) in
-        qs, spec, false, None, [ decl, None, None ]
-      ) fields), k (Ident name)
+      qs, Union (None, mk_union_fields m fields), k (Ident name)
 
 and mk_fields m fields =
   Some (List.map (fun (name, typ) ->
     let name = match name with Some name -> name | None -> "" in
     let qs, spec, decl = mk_spec_and_declarator m name typ in
+    qs, spec, false, None, [ decl, None, None ]
+  ) fields)
+
+and mk_union_fields m fields =
+  Some (List.map (fun (name, typ) ->
+    let qs, spec, decl = mk_spec_and_decl m name [] typ (fun d -> d) in
     qs, spec, false, None, [ decl, None, None ]
   ) fields)
 
@@ -281,6 +284,8 @@ and mk_spec_and_declarator_t m name t =
        * unique, therefore, post-fixing them with "_s" also generates a set of
        * unique struct names. *)
       [], C.Struct (Some (name ^ "_s"), mk_fields m fields), Ident name
+  | Union fields ->
+      [], C.Union (Some (name ^ "_s"), mk_union_fields m fields), Ident name
   | _ ->
       mk_spec_and_declarator m name t
 
@@ -1140,16 +1145,20 @@ let hand_written lid =
  * are either declared in the header (public), or in the c file (private), but
  * not twice. *)
 let mk_type_or_external m (w: where) ?(is_inline_static=false) (d: decl): C.declaration_or_function list =
-  let mk_forward_decl name flags =
-    wrap_verbatim name flags (Decl ([], ([], C.Struct (Some (name ^ "_s"), None), false, Some Typedef, [ Ident name, None, None ])))
+  let mk_forward_decl name flags k =
+    let d = match k with
+      | FStruct -> C.Struct (Some (name ^ "_s"), None)
+      | FUnion -> C.Union (Some (name ^ "_s"), None)
+    in
+    wrap_verbatim name flags (Decl ([], ([], d, false, Some Typedef, [ Ident name, None, None ])))
   in
   match replace_decl d with
-  | TypeForward (name, flags) ->
+  | TypeForward (name, flags, k) ->
       let name = to_c_name m name in
-      mk_forward_decl name flags
+      mk_forward_decl name flags k
   | Type (name, Struct _, flags) when w = H && List.mem AbstractStruct flags ->
       let name = to_c_name m name in
-      mk_forward_decl name flags
+      mk_forward_decl name flags FStruct
   | Type (name, t, flags) ->
       if is_primitive name || (is_inline_static && declared_in_library name) then
         []
@@ -1219,7 +1228,7 @@ let flags_of_decl (d: CStar.decl) =
   | Global (_, _, flags, _, _)
   | Function (_, flags, _, _, _, _)
   | Type (_, _, flags)
-  | TypeForward (_, flags)
+  | TypeForward (_, flags, _)
   | External (_, _, flags, _) ->
       flags
 

--- a/src/Common.ml
+++ b/src/Common.ml
@@ -13,6 +13,11 @@ type lifetime =
   | Heap
   [@@deriving yojson,show]
 
+type forward_kind =
+  | FUnion
+  | FStruct
+  [@@deriving yojson,show]
+
 type flag =
   | Private
       (** An F* private qualifier. *)

--- a/src/DataTypes.ml
+++ b/src/DataTypes.ml
@@ -224,7 +224,7 @@ let build_scheme_map files =
     method visit_DType _ lid _ _ d =
       (* But if it turns out we can't eliminate, restore what otherwise would've
        * been the compilation scheme. (See OCaml doc for the behavior of add.) *)
-      if d = Forward then
+      if Helpers.is_forward d then
         match Hashtbl.find map lid with
         | exception Not_found ->
             ()

--- a/src/Diagnostics.ml
+++ b/src/Diagnostics.ml
@@ -18,7 +18,7 @@ let types_depth files =
   let incr (d, p) = d + 1, p in
 
   let rec compute_depth lid (d: type_def) =
-    if not (Hashtbl.mem seen lid) && d <> Forward then
+    if not (Hashtbl.mem seen lid) && not (Helpers.is_forward d) then
       Hashtbl.add seen lid (depth_of_def [] d)
 
   and depth_of_def p d =
@@ -27,7 +27,7 @@ let types_depth files =
         depth_of_type p t
     | Flat fields ->
         incr (KList.max (List.map (fun (f, (t, _)) -> depth_of_type (Option.must f :: p) t) fields))
-    | Forward
+    | Forward _
     | Variant _ ->
         failwith "impossible"
     | Enum _ ->

--- a/src/Helpers.ml
+++ b/src/Helpers.ml
@@ -181,6 +181,10 @@ let is_null = function
   | { node = EBufNull; _ } -> true
   | _ -> false
 
+let is_forward = function
+  | Forward _ -> true
+  | _ -> false
+
 let is_uu name = KString.starts_with name "uu__"
 
 let pattern_matches p lid =

--- a/src/InputAstToAst.ml
+++ b/src/InputAstToAst.ml
@@ -55,7 +55,7 @@ let rec mk_decl = function
       DType (name, flags, n,
         Variant (List.map (fun (ident, fields) -> ident, mk_tfields fields) branches))
   | I.DTypeAbstractStruct name ->
-      DType (name, [], 0, Forward)
+      DType (name, [], 0, Forward FStruct)
   | I.DUntaggedUnion (name, flags, n, branches) ->
       DType (name, flags, n, Union (List.map (fun (f, t) -> f, mk_typ t) branches))
 

--- a/src/Monomorphization.ml
+++ b/src/Monomorphization.ml
@@ -175,7 +175,7 @@ let monomorphize_data_types map = object(self)
           begin match Hashtbl.find map lid with
           | exception Not_found ->
               Hashtbl.replace state n (Black, chosen_lid)
-          | flags, (Variant _ | Flat _ | Union _) when under_ref && not (Hashtbl.mem seen_declarations lid) ->
+          | flags, ((Variant _ | Flat _ | Union _) as def) when under_ref && not (Hashtbl.mem seen_declarations lid) ->
               (* Because this looks up a definition in the global map, the
                  definitions are reordered according to the traversal order, which
                  is generally a good idea (we accept more programs!), EXCEPT
@@ -194,7 +194,10 @@ let monomorphize_data_types map = object(self)
                    particular traversal)... *)
               if Options.debug "data-types-traversal" then
                 KPrint.bprintf "DEFERRING %a<%a>\n" plid (fst n) ptyps (snd n);
-              self#record (DType (chosen_lid, flags, 0, Forward));
+              if match def with Union _ -> true | _ -> false then
+                self#record (DType (chosen_lid, flags, 0, Forward FUnion))
+              else
+                self#record (DType (chosen_lid, flags, 0, Forward FStruct));
               Hashtbl.add pending_monomorphizations (fst n) (snd n);
               Hashtbl.remove state n
           | flags, Variant branches ->
@@ -230,8 +233,10 @@ let monomorphize_data_types map = object(self)
         begin match Hashtbl.find map lid with
         | exception Not_found ->
             ()
+        | flags, Union _ ->
+            self#record (DType (chosen_lid, flags, 0, Forward FUnion))
         | flags, _ ->
-            self#record (DType (chosen_lid, flags, 0, Forward))
+            self#record (DType (chosen_lid, flags, 0, Forward FStruct))
         end;
         chosen_lid
     | Black, chosen_lid ->
@@ -550,8 +555,9 @@ let equalities files =
 
     method private maybe_by_addr head x y =
       let t_op, x, y =
+        let is_forward = function Some Forward _ -> true | _ -> false in
         match x.typ with
-        | TQualified lid when Hashtbl.find_opt types_map lid = Some Forward ->
+        | TQualified lid when is_forward (Hashtbl.find_opt types_map lid) ->
             let t = TBuf (x.typ, true) in
             TArrow (t, TArrow (t, TBool)), with_type t (EAddrOf x), with_type t (EAddrOf y)
         | _ ->
@@ -651,7 +657,7 @@ let equalities files =
                  * No Enum / Union / Forward (this runs before data types). *)
                 assert false
 
-            | Forward ->
+            | Forward _ ->
                 (* Happens when an abstract external type is marked as
                    CAbstractStruct. TODO this is really unpleasant because
                    without the annotation, the type wouldn't be generated at all

--- a/src/PrintAst.ml
+++ b/src/PrintAst.ml
@@ -87,8 +87,11 @@ and print_type_def = function
       string "abbrev" ^/^
       jump (print_typ typ)
 
-  | Forward ->
-      string "forward"
+  | Forward FStruct ->
+      string "forward struct"
+
+  | Forward FUnion ->
+      string "forward union"
 
 and print_fields_t fields =
   separate_map (semi ^^ break1) (fun (ident, (typ, mut)) ->

--- a/src/PrintC.ml
+++ b/src/PrintC.ml
@@ -69,7 +69,11 @@ let rec p_type_spec = function
   | Union (name, decls) ->
       group (string "union" ^/^
       (match name with Some name -> string name ^^ break1 | None -> empty)) ^^
-      braces_with_nesting (separate_map hardline (fun p -> group (p_declaration p ^^ semi)) decls)
+      (match decls with
+      | Some decls ->
+          braces_with_nesting (separate_map hardline (fun p -> group (p_declaration p ^^ semi)) decls)
+      | None ->
+          empty)
   | Struct (name, decls) ->
       group (string "struct" ^/^
       (match name with Some name -> string name | None -> empty)) ^^

--- a/src/Simplify.ml
+++ b/src/Simplify.ml
@@ -1385,7 +1385,7 @@ let record_toplevel_names = object (self)
       self#record env ~is_type:true ~is_external:false flags name;
     match def with
     | Enum lids -> List.iter (self#record env ~is_type:true ~is_external:false flags) lids
-    | Forward -> Hashtbl.add forward name ()
+    | Forward _ -> Hashtbl.add forward name ()
     | _ -> ()
 end
 


### PR DESCRIPTION
@tahina-pro can you confirm this works for you?

With SteelC now generating anonymous unions, krml needs to consider anonymous union type declarations in the phase that:
- emits type declarations, while
- monomorphizing them, and
- emitting forward declarations in case there is mutual recursion
- and preserving the order so long as the declarations are referred to behind pointers.