### PR TITLE
Void loop index to avoid unused-but-set-variable warning

### DIFF
--- a/include/krml/internal/target.h
+++ b/include/krml/internal/target.h
@@ -169,6 +169,7 @@ inline static int32_t krml_time(void) {
 #define KRML_LOOP1(i, n, x) { \
   x \
   i += n; \
+  (void) i; \
 }
 
 #define KRML_LOOP2(i, n, x) \


### PR DESCRIPTION
This PR does a simple fix (suggested by @protz) to fix the unused-but-set-variable warning on loop indexes in unrolled loops that use the macros in target.h. 