### PR TITLE
proper treatment of inline/noinline on externals

### DIFF
--- a/krmllib/js/loader.js
+++ b/krmllib/js/loader.js
@@ -251,6 +251,10 @@ let mkLibMemzero = (mem) => ({
   }
 });
 
+let mkLowStarIgnore = (mem) => ({
+  LowStar_Ignore_ignore: () => { }
+});
+
 let mkLowStarEndianness = (mem) => ({
   htole16: (x) => { throw new Error("todo: htole16") },
   le16toh: (x) => { throw new Error("todo: le16toh") },
@@ -481,7 +485,8 @@ function init() {
     TestLib: mkTestLib(mem, 'TestLib'),
     TestLib_Compat: mkTestLib(mem, 'TestLib_Compat'),
     Lib_RandomBuffer_System: mkLibRandomBufferSystem(mem),
-    Lib_Memzero: mkLibMemzero(mem)
+    Lib_Memzero: mkLibMemzero(mem),
+    LowStar_Ignore: mkLowStarIgnore(mem)
   };
   return imports;
 }

--- a/lib/CStarToC11.ml
+++ b/lib/CStarToC11.ml
@@ -1203,7 +1203,15 @@ let mk_type_or_external m (w: where) ?(is_inline_static=false) (d: decl): C.decl
             fst (KList.split (List.length ts) pp)
         in
         let qs, spec, decl = mk_spec_and_declarator_f m cc name t (List.combine arg_names ts) in
-        wrap_verbatim name flags (Decl (mk_comments flags, (qs, spec, None, Some Extern, [ decl, None, None ])))
+        let inline =
+          if List.mem NoInline flags then
+            Some C11.NoInline
+          else if List.mem Inline flags then
+            Some C11.Inline
+          else
+            None
+        in
+        wrap_verbatim name flags (Decl (mk_comments flags, (qs, spec, inline, Some Extern, [ decl, None, None ])))
 
   | External (name, t, flags, _) ->
       if is_primitive name ||


### PR DESCRIPTION
this was caught by the everest build because the osx does not seem to mind the prototype discrepancies