### PR TITLE
Surround static KRML_NOINLINE declarations with pragmas to disable unused function warnings

### DIFF
--- a/include/krml/internal/target.h
+++ b/include/krml/internal/target.h
@@ -58,14 +58,22 @@
 #endif
 
 #ifndef KRML_NOINLINE_START
-#  define KRML_NOINLINE_START \
-  _Pragma("GCC diagnostic push") \
-  _Pragma("GCC diagnostic ignored \"-Wunused-function\"")
+#  if defined (__GNUC__)
+#    define KRML_NOINLINE_START \
+       _Pragma("GCC diagnostic push") \
+       _Pragma("GCC diagnostic ignored \"-Wunused-function\"")
+#  else
+#    define KRML_NOINLINE_START
+#  endif
 #endif
 
 #ifndef KRML_NOINLINE_END
-#  define KRML_NOINLINE_END \
-  _Pragma("GCC diagnostic pop")
+#  if defined (__GNUC__)
+#    define KRML_NOINLINE_END \
+      _Pragma("GCC diagnostic pop")
+#  else
+#    define KRML_NOINLINE_START
+#  endif
 #endif
 
 #ifndef KRML_NOINLINE

--- a/include/krml/internal/target.h
+++ b/include/krml/internal/target.h
@@ -57,6 +57,17 @@
 #  define KRML_HOST_IGNORE(x) (void)(x)
 #endif
 
+#ifndef KRML_NOINLINE_START
+#  define KRML_NOINLINE_START \
+  _Pragma("GCC diagnostic push") \
+  _Pragma("GCC diagnostic ignored \"-Wunused-function\"")
+#endif
+
+#ifndef KRML_NOINLINE_END
+#  define KRML_NOINLINE_END \
+  _Pragma("GCC diagnostic pop")
+#endif
+
 #ifndef KRML_NOINLINE
 #  if defined(_MSC_VER)
 #    define KRML_NOINLINE __declspec(noinline)

--- a/krmllib/dist/generic/FStar_UInt_8_16_32_64.h
+++ b/krmllib/dist/generic/FStar_UInt_8_16_32_64.h
@@ -30,6 +30,8 @@ extern uint64_t FStar_UInt64_minus(uint64_t a);
 
 extern uint32_t FStar_UInt64_n_minus_one;
 
+KRML_NOINLINE_START
+
 static KRML_NOINLINE uint64_t FStar_UInt64_eq_mask(uint64_t a, uint64_t b)
 {
   uint64_t x = a ^ b;
@@ -38,6 +40,10 @@ static KRML_NOINLINE uint64_t FStar_UInt64_eq_mask(uint64_t a, uint64_t b)
   uint64_t xnx = x_or_minus_x >> (uint32_t)63U;
   return xnx - (uint64_t)1U;
 }
+
+KRML_NOINLINE_END
+
+KRML_NOINLINE_START
 
 static KRML_NOINLINE uint64_t FStar_UInt64_gte_mask(uint64_t a, uint64_t b)
 {
@@ -51,6 +57,8 @@ static KRML_NOINLINE uint64_t FStar_UInt64_gte_mask(uint64_t a, uint64_t b)
   uint64_t x_xor_q_ = x_xor_q >> (uint32_t)63U;
   return x_xor_q_ - (uint64_t)1U;
 }
+
+KRML_NOINLINE_END
 
 extern Prims_string FStar_UInt64_to_string(uint64_t uu___);
 
@@ -78,6 +86,8 @@ extern uint32_t FStar_UInt32_minus(uint32_t a);
 
 extern uint32_t FStar_UInt32_n_minus_one;
 
+KRML_NOINLINE_START
+
 static KRML_NOINLINE uint32_t FStar_UInt32_eq_mask(uint32_t a, uint32_t b)
 {
   uint32_t x = a ^ b;
@@ -86,6 +96,10 @@ static KRML_NOINLINE uint32_t FStar_UInt32_eq_mask(uint32_t a, uint32_t b)
   uint32_t xnx = x_or_minus_x >> (uint32_t)31U;
   return xnx - (uint32_t)1U;
 }
+
+KRML_NOINLINE_END
+
+KRML_NOINLINE_START
 
 static KRML_NOINLINE uint32_t FStar_UInt32_gte_mask(uint32_t a, uint32_t b)
 {
@@ -99,6 +113,8 @@ static KRML_NOINLINE uint32_t FStar_UInt32_gte_mask(uint32_t a, uint32_t b)
   uint32_t x_xor_q_ = x_xor_q >> (uint32_t)31U;
   return x_xor_q_ - (uint32_t)1U;
 }
+
+KRML_NOINLINE_END
 
 extern Prims_string FStar_UInt32_to_string(uint32_t uu___);
 
@@ -126,6 +142,8 @@ extern uint16_t FStar_UInt16_minus(uint16_t a);
 
 extern uint32_t FStar_UInt16_n_minus_one;
 
+KRML_NOINLINE_START
+
 static KRML_NOINLINE uint16_t FStar_UInt16_eq_mask(uint16_t a, uint16_t b)
 {
   uint16_t x = a ^ b;
@@ -134,6 +152,10 @@ static KRML_NOINLINE uint16_t FStar_UInt16_eq_mask(uint16_t a, uint16_t b)
   uint16_t xnx = x_or_minus_x >> (uint32_t)15U;
   return xnx - (uint16_t)1U;
 }
+
+KRML_NOINLINE_END
+
+KRML_NOINLINE_START
 
 static KRML_NOINLINE uint16_t FStar_UInt16_gte_mask(uint16_t a, uint16_t b)
 {
@@ -147,6 +169,8 @@ static KRML_NOINLINE uint16_t FStar_UInt16_gte_mask(uint16_t a, uint16_t b)
   uint16_t x_xor_q_ = x_xor_q >> (uint32_t)15U;
   return x_xor_q_ - (uint16_t)1U;
 }
+
+KRML_NOINLINE_END
 
 extern Prims_string FStar_UInt16_to_string(uint16_t uu___);
 
@@ -174,6 +198,8 @@ extern uint8_t FStar_UInt8_minus(uint8_t a);
 
 extern uint32_t FStar_UInt8_n_minus_one;
 
+KRML_NOINLINE_START
+
 static KRML_NOINLINE uint8_t FStar_UInt8_eq_mask(uint8_t a, uint8_t b)
 {
   uint8_t x = a ^ b;
@@ -182,6 +208,10 @@ static KRML_NOINLINE uint8_t FStar_UInt8_eq_mask(uint8_t a, uint8_t b)
   uint8_t xnx = x_or_minus_x >> (uint32_t)7U;
   return xnx - (uint8_t)1U;
 }
+
+KRML_NOINLINE_END
+
+KRML_NOINLINE_START
 
 static KRML_NOINLINE uint8_t FStar_UInt8_gte_mask(uint8_t a, uint8_t b)
 {
@@ -195,6 +225,8 @@ static KRML_NOINLINE uint8_t FStar_UInt8_gte_mask(uint8_t a, uint8_t b)
   uint8_t x_xor_q_ = x_xor_q >> (uint32_t)7U;
   return x_xor_q_ - (uint8_t)1U;
 }
+
+KRML_NOINLINE_END
 
 extern Prims_string FStar_UInt8_to_string(uint8_t uu___);
 

--- a/krmllib/dist/minimal/FStar_UInt_8_16_32_64.h
+++ b/krmllib/dist/minimal/FStar_UInt_8_16_32_64.h
@@ -32,6 +32,8 @@ extern uint64_t FStar_UInt64_minus(uint64_t a);
 
 extern uint32_t FStar_UInt64_n_minus_one;
 
+KRML_NOINLINE_START
+
 static KRML_NOINLINE uint64_t FStar_UInt64_eq_mask(uint64_t a, uint64_t b)
 {
   uint64_t x = a ^ b;
@@ -40,6 +42,10 @@ static KRML_NOINLINE uint64_t FStar_UInt64_eq_mask(uint64_t a, uint64_t b)
   uint64_t xnx = x_or_minus_x >> (uint32_t)63U;
   return xnx - (uint64_t)1U;
 }
+
+KRML_NOINLINE_END
+
+KRML_NOINLINE_START
 
 static KRML_NOINLINE uint64_t FStar_UInt64_gte_mask(uint64_t a, uint64_t b)
 {
@@ -53,6 +59,8 @@ static KRML_NOINLINE uint64_t FStar_UInt64_gte_mask(uint64_t a, uint64_t b)
   uint64_t x_xor_q_ = x_xor_q >> (uint32_t)63U;
   return x_xor_q_ - (uint64_t)1U;
 }
+
+KRML_NOINLINE_END
 
 extern Prims_string FStar_UInt64_to_string(uint64_t uu___);
 
@@ -80,6 +88,8 @@ extern uint32_t FStar_UInt32_minus(uint32_t a);
 
 extern uint32_t FStar_UInt32_n_minus_one;
 
+KRML_NOINLINE_START
+
 static KRML_NOINLINE uint32_t FStar_UInt32_eq_mask(uint32_t a, uint32_t b)
 {
   uint32_t x = a ^ b;
@@ -88,6 +98,10 @@ static KRML_NOINLINE uint32_t FStar_UInt32_eq_mask(uint32_t a, uint32_t b)
   uint32_t xnx = x_or_minus_x >> (uint32_t)31U;
   return xnx - (uint32_t)1U;
 }
+
+KRML_NOINLINE_END
+
+KRML_NOINLINE_START
 
 static KRML_NOINLINE uint32_t FStar_UInt32_gte_mask(uint32_t a, uint32_t b)
 {
@@ -101,6 +115,8 @@ static KRML_NOINLINE uint32_t FStar_UInt32_gte_mask(uint32_t a, uint32_t b)
   uint32_t x_xor_q_ = x_xor_q >> (uint32_t)31U;
   return x_xor_q_ - (uint32_t)1U;
 }
+
+KRML_NOINLINE_END
 
 extern Prims_string FStar_UInt32_to_string(uint32_t uu___);
 
@@ -128,6 +144,8 @@ extern uint16_t FStar_UInt16_minus(uint16_t a);
 
 extern uint32_t FStar_UInt16_n_minus_one;
 
+KRML_NOINLINE_START
+
 static KRML_NOINLINE uint16_t FStar_UInt16_eq_mask(uint16_t a, uint16_t b)
 {
   uint16_t x = a ^ b;
@@ -136,6 +154,10 @@ static KRML_NOINLINE uint16_t FStar_UInt16_eq_mask(uint16_t a, uint16_t b)
   uint16_t xnx = x_or_minus_x >> (uint32_t)15U;
   return xnx - (uint16_t)1U;
 }
+
+KRML_NOINLINE_END
+
+KRML_NOINLINE_START
 
 static KRML_NOINLINE uint16_t FStar_UInt16_gte_mask(uint16_t a, uint16_t b)
 {
@@ -149,6 +171,8 @@ static KRML_NOINLINE uint16_t FStar_UInt16_gte_mask(uint16_t a, uint16_t b)
   uint16_t x_xor_q_ = x_xor_q >> (uint32_t)15U;
   return x_xor_q_ - (uint16_t)1U;
 }
+
+KRML_NOINLINE_END
 
 extern Prims_string FStar_UInt16_to_string(uint16_t uu___);
 
@@ -176,6 +200,8 @@ extern uint8_t FStar_UInt8_minus(uint8_t a);
 
 extern uint32_t FStar_UInt8_n_minus_one;
 
+KRML_NOINLINE_START
+
 static KRML_NOINLINE uint8_t FStar_UInt8_eq_mask(uint8_t a, uint8_t b)
 {
   uint8_t x = a ^ b;
@@ -184,6 +210,10 @@ static KRML_NOINLINE uint8_t FStar_UInt8_eq_mask(uint8_t a, uint8_t b)
   uint8_t xnx = x_or_minus_x >> (uint32_t)7U;
   return xnx - (uint8_t)1U;
 }
+
+KRML_NOINLINE_END
+
+KRML_NOINLINE_START
 
 static KRML_NOINLINE uint8_t FStar_UInt8_gte_mask(uint8_t a, uint8_t b)
 {
@@ -197,6 +227,8 @@ static KRML_NOINLINE uint8_t FStar_UInt8_gte_mask(uint8_t a, uint8_t b)
   uint8_t x_xor_q_ = x_xor_q >> (uint32_t)7U;
   return x_xor_q_ - (uint8_t)1U;
 }
+
+KRML_NOINLINE_END
 
 extern Prims_string FStar_UInt8_to_string(uint8_t uu___);
 

--- a/krmllib/dist/uint128/FStar_UInt_8_16_32_64.h
+++ b/krmllib/dist/uint128/FStar_UInt_8_16_32_64.h
@@ -12,6 +12,8 @@
 #include "krml/internal/types.h"
 #include "krml/internal/target.h"
 
+KRML_NOINLINE_START
+
 static KRML_NOINLINE uint64_t FStar_UInt64_eq_mask(uint64_t a, uint64_t b)
 {
   uint64_t x = a ^ b;
@@ -20,6 +22,10 @@ static KRML_NOINLINE uint64_t FStar_UInt64_eq_mask(uint64_t a, uint64_t b)
   uint64_t xnx = x_or_minus_x >> (uint32_t)63U;
   return xnx - (uint64_t)1U;
 }
+
+KRML_NOINLINE_END
+
+KRML_NOINLINE_START
 
 static KRML_NOINLINE uint64_t FStar_UInt64_gte_mask(uint64_t a, uint64_t b)
 {
@@ -33,6 +39,8 @@ static KRML_NOINLINE uint64_t FStar_UInt64_gte_mask(uint64_t a, uint64_t b)
   uint64_t x_xor_q_ = x_xor_q >> (uint32_t)63U;
   return x_xor_q_ - (uint64_t)1U;
 }
+
+KRML_NOINLINE_END
 
 
 #define __FStar_UInt_8_16_32_64_H_DEFINED


### PR DESCRIPTION
It's kind of inevitable, so doing it on a per-function basis. Those will be removed at link-time.