### PR TITLE
NOINLINE improvement

### DIFF
--- a/include/krml/internal/target.h
+++ b/include/krml/internal/target.h
@@ -57,30 +57,11 @@
 #  define KRML_HOST_IGNORE(x) (void)(x)
 #endif
 
-#ifndef KRML_NOINLINE_START
-#  if defined (__GNUC__)
-#    define KRML_NOINLINE_START \
-       _Pragma("GCC diagnostic push") \
-       _Pragma("GCC diagnostic ignored \"-Wunused-function\"")
-#  else
-#    define KRML_NOINLINE_START
-#  endif
-#endif
-
-#ifndef KRML_NOINLINE_END
-#  if defined (__GNUC__)
-#    define KRML_NOINLINE_END \
-      _Pragma("GCC diagnostic pop")
-#  else
-#    define KRML_NOINLINE_END
-#  endif
-#endif
-
 #ifndef KRML_NOINLINE
 #  if defined(_MSC_VER)
 #    define KRML_NOINLINE __declspec(noinline)
 #  elif defined (__GNUC__)
-#    define KRML_NOINLINE __attribute__((noinline))
+#    define KRML_NOINLINE __attribute__((noinline,unused))
 #  else
 #    define KRML_NOINLINE
 #    warning "The KRML_NOINLINE macro is not defined for this toolchain!"

--- a/krmllib/dist/generic/FStar_BV.c
+++ b/krmllib/dist/generic/FStar_BV.c
@@ -323,19 +323,6 @@ Prims_list__bool
 }
 
 Prims_list__bool
-*FStar_BV_bvdiv_unsafe(krml_checked_int_t n, Prims_list__bool *a, Prims_list__bool *b)
-{
-  if (FStar_BV_bv2int(n, b) != (krml_checked_int_t)0)
-  {
-    return FStar_BV_bvdiv(n, a, FStar_BV_bv2int(n, b));
-  }
-  else
-  {
-    return FStar_BV_int2bv(n, (krml_checked_int_t)0);
-  }
-}
-
-Prims_list__bool
 *FStar_BV_bvmod(krml_checked_int_t n, Prims_list__bool *a, krml_checked_int_t b)
 {
   return FStar_BV_int2bv(n, FStar_UInt_mod(n, FStar_BV_bv2int(n, a), b));

--- a/krmllib/dist/generic/FStar_BV.h
+++ b/krmllib/dist/generic/FStar_BV.h
@@ -94,9 +94,6 @@ Prims_list__bool
 *FStar_BV_bvdiv(krml_checked_int_t n, Prims_list__bool *a, krml_checked_int_t b);
 
 Prims_list__bool
-*FStar_BV_bvdiv_unsafe(krml_checked_int_t n, Prims_list__bool *a, Prims_list__bool *b);
-
-Prims_list__bool
 *FStar_BV_bvmod(krml_checked_int_t n, Prims_list__bool *a, krml_checked_int_t b);
 
 Prims_list__bool

--- a/krmllib/dist/generic/FStar_UInt_8_16_32_64.h
+++ b/krmllib/dist/generic/FStar_UInt_8_16_32_64.h
@@ -30,8 +30,6 @@ extern uint64_t FStar_UInt64_minus(uint64_t a);
 
 extern uint32_t FStar_UInt64_n_minus_one;
 
-KRML_NOINLINE_START
-
 static KRML_NOINLINE uint64_t FStar_UInt64_eq_mask(uint64_t a, uint64_t b)
 {
   uint64_t x = a ^ b;
@@ -40,10 +38,6 @@ static KRML_NOINLINE uint64_t FStar_UInt64_eq_mask(uint64_t a, uint64_t b)
   uint64_t xnx = x_or_minus_x >> (uint32_t)63U;
   return xnx - (uint64_t)1U;
 }
-
-KRML_NOINLINE_END
-
-KRML_NOINLINE_START
 
 static KRML_NOINLINE uint64_t FStar_UInt64_gte_mask(uint64_t a, uint64_t b)
 {
@@ -57,8 +51,6 @@ static KRML_NOINLINE uint64_t FStar_UInt64_gte_mask(uint64_t a, uint64_t b)
   uint64_t x_xor_q_ = x_xor_q >> (uint32_t)63U;
   return x_xor_q_ - (uint64_t)1U;
 }
-
-KRML_NOINLINE_END
 
 extern Prims_string FStar_UInt64_to_string(uint64_t uu___);
 
@@ -86,8 +78,6 @@ extern uint32_t FStar_UInt32_minus(uint32_t a);
 
 extern uint32_t FStar_UInt32_n_minus_one;
 
-KRML_NOINLINE_START
-
 static KRML_NOINLINE uint32_t FStar_UInt32_eq_mask(uint32_t a, uint32_t b)
 {
   uint32_t x = a ^ b;
@@ -96,10 +86,6 @@ static KRML_NOINLINE uint32_t FStar_UInt32_eq_mask(uint32_t a, uint32_t b)
   uint32_t xnx = x_or_minus_x >> (uint32_t)31U;
   return xnx - (uint32_t)1U;
 }
-
-KRML_NOINLINE_END
-
-KRML_NOINLINE_START
 
 static KRML_NOINLINE uint32_t FStar_UInt32_gte_mask(uint32_t a, uint32_t b)
 {
@@ -113,8 +99,6 @@ static KRML_NOINLINE uint32_t FStar_UInt32_gte_mask(uint32_t a, uint32_t b)
   uint32_t x_xor_q_ = x_xor_q >> (uint32_t)31U;
   return x_xor_q_ - (uint32_t)1U;
 }
-
-KRML_NOINLINE_END
 
 extern Prims_string FStar_UInt32_to_string(uint32_t uu___);
 
@@ -142,8 +126,6 @@ extern uint16_t FStar_UInt16_minus(uint16_t a);
 
 extern uint32_t FStar_UInt16_n_minus_one;
 
-KRML_NOINLINE_START
-
 static KRML_NOINLINE uint16_t FStar_UInt16_eq_mask(uint16_t a, uint16_t b)
 {
   uint16_t x = a ^ b;
@@ -152,10 +134,6 @@ static KRML_NOINLINE uint16_t FStar_UInt16_eq_mask(uint16_t a, uint16_t b)
   uint16_t xnx = x_or_minus_x >> (uint32_t)15U;
   return xnx - (uint16_t)1U;
 }
-
-KRML_NOINLINE_END
-
-KRML_NOINLINE_START
 
 static KRML_NOINLINE uint16_t FStar_UInt16_gte_mask(uint16_t a, uint16_t b)
 {
@@ -169,8 +147,6 @@ static KRML_NOINLINE uint16_t FStar_UInt16_gte_mask(uint16_t a, uint16_t b)
   uint16_t x_xor_q_ = x_xor_q >> (uint32_t)15U;
   return x_xor_q_ - (uint16_t)1U;
 }
-
-KRML_NOINLINE_END
 
 extern Prims_string FStar_UInt16_to_string(uint16_t uu___);
 
@@ -198,8 +174,6 @@ extern uint8_t FStar_UInt8_minus(uint8_t a);
 
 extern uint32_t FStar_UInt8_n_minus_one;
 
-KRML_NOINLINE_START
-
 static KRML_NOINLINE uint8_t FStar_UInt8_eq_mask(uint8_t a, uint8_t b)
 {
   uint8_t x = a ^ b;
@@ -208,10 +182,6 @@ static KRML_NOINLINE uint8_t FStar_UInt8_eq_mask(uint8_t a, uint8_t b)
   uint8_t xnx = x_or_minus_x >> (uint32_t)7U;
   return xnx - (uint8_t)1U;
 }
-
-KRML_NOINLINE_END
-
-KRML_NOINLINE_START
 
 static KRML_NOINLINE uint8_t FStar_UInt8_gte_mask(uint8_t a, uint8_t b)
 {
@@ -225,8 +195,6 @@ static KRML_NOINLINE uint8_t FStar_UInt8_gte_mask(uint8_t a, uint8_t b)
   uint8_t x_xor_q_ = x_xor_q >> (uint32_t)7U;
   return x_xor_q_ - (uint8_t)1U;
 }
-
-KRML_NOINLINE_END
 
 extern Prims_string FStar_UInt8_to_string(uint8_t uu___);
 

--- a/krmllib/dist/generic/libkrmllib.def
+++ b/krmllib/dist/generic/libkrmllib.def
@@ -37,7 +37,6 @@ EXPORTS
   FStar_BV_bvadd
   FStar_BV_bvsub
   FStar_BV_bvdiv
-  FStar_BV_bvdiv_unsafe
   FStar_BV_bvmod
   FStar_BV_bvmul
   FStar_Order_uu___is_Lt

--- a/krmllib/dist/minimal/FStar_UInt_8_16_32_64.h
+++ b/krmllib/dist/minimal/FStar_UInt_8_16_32_64.h
@@ -32,8 +32,6 @@ extern uint64_t FStar_UInt64_minus(uint64_t a);
 
 extern uint32_t FStar_UInt64_n_minus_one;
 
-KRML_NOINLINE_START
-
 static KRML_NOINLINE uint64_t FStar_UInt64_eq_mask(uint64_t a, uint64_t b)
 {
   uint64_t x = a ^ b;
@@ -42,10 +40,6 @@ static KRML_NOINLINE uint64_t FStar_UInt64_eq_mask(uint64_t a, uint64_t b)
   uint64_t xnx = x_or_minus_x >> (uint32_t)63U;
   return xnx - (uint64_t)1U;
 }
-
-KRML_NOINLINE_END
-
-KRML_NOINLINE_START
 
 static KRML_NOINLINE uint64_t FStar_UInt64_gte_mask(uint64_t a, uint64_t b)
 {
@@ -59,8 +53,6 @@ static KRML_NOINLINE uint64_t FStar_UInt64_gte_mask(uint64_t a, uint64_t b)
   uint64_t x_xor_q_ = x_xor_q >> (uint32_t)63U;
   return x_xor_q_ - (uint64_t)1U;
 }
-
-KRML_NOINLINE_END
 
 extern Prims_string FStar_UInt64_to_string(uint64_t uu___);
 
@@ -88,8 +80,6 @@ extern uint32_t FStar_UInt32_minus(uint32_t a);
 
 extern uint32_t FStar_UInt32_n_minus_one;
 
-KRML_NOINLINE_START
-
 static KRML_NOINLINE uint32_t FStar_UInt32_eq_mask(uint32_t a, uint32_t b)
 {
   uint32_t x = a ^ b;
@@ -98,10 +88,6 @@ static KRML_NOINLINE uint32_t FStar_UInt32_eq_mask(uint32_t a, uint32_t b)
   uint32_t xnx = x_or_minus_x >> (uint32_t)31U;
   return xnx - (uint32_t)1U;
 }
-
-KRML_NOINLINE_END
-
-KRML_NOINLINE_START
 
 static KRML_NOINLINE uint32_t FStar_UInt32_gte_mask(uint32_t a, uint32_t b)
 {
@@ -115,8 +101,6 @@ static KRML_NOINLINE uint32_t FStar_UInt32_gte_mask(uint32_t a, uint32_t b)
   uint32_t x_xor_q_ = x_xor_q >> (uint32_t)31U;
   return x_xor_q_ - (uint32_t)1U;
 }
-
-KRML_NOINLINE_END
 
 extern Prims_string FStar_UInt32_to_string(uint32_t uu___);
 
@@ -144,8 +128,6 @@ extern uint16_t FStar_UInt16_minus(uint16_t a);
 
 extern uint32_t FStar_UInt16_n_minus_one;
 
-KRML_NOINLINE_START
-
 static KRML_NOINLINE uint16_t FStar_UInt16_eq_mask(uint16_t a, uint16_t b)
 {
   uint16_t x = a ^ b;
@@ -154,10 +136,6 @@ static KRML_NOINLINE uint16_t FStar_UInt16_eq_mask(uint16_t a, uint16_t b)
   uint16_t xnx = x_or_minus_x >> (uint32_t)15U;
   return xnx - (uint16_t)1U;
 }
-
-KRML_NOINLINE_END
-
-KRML_NOINLINE_START
 
 static KRML_NOINLINE uint16_t FStar_UInt16_gte_mask(uint16_t a, uint16_t b)
 {
@@ -171,8 +149,6 @@ static KRML_NOINLINE uint16_t FStar_UInt16_gte_mask(uint16_t a, uint16_t b)
   uint16_t x_xor_q_ = x_xor_q >> (uint32_t)15U;
   return x_xor_q_ - (uint16_t)1U;
 }
-
-KRML_NOINLINE_END
 
 extern Prims_string FStar_UInt16_to_string(uint16_t uu___);
 
@@ -200,8 +176,6 @@ extern uint8_t FStar_UInt8_minus(uint8_t a);
 
 extern uint32_t FStar_UInt8_n_minus_one;
 
-KRML_NOINLINE_START
-
 static KRML_NOINLINE uint8_t FStar_UInt8_eq_mask(uint8_t a, uint8_t b)
 {
   uint8_t x = a ^ b;
@@ -210,10 +184,6 @@ static KRML_NOINLINE uint8_t FStar_UInt8_eq_mask(uint8_t a, uint8_t b)
   uint8_t xnx = x_or_minus_x >> (uint32_t)7U;
   return xnx - (uint8_t)1U;
 }
-
-KRML_NOINLINE_END
-
-KRML_NOINLINE_START
 
 static KRML_NOINLINE uint8_t FStar_UInt8_gte_mask(uint8_t a, uint8_t b)
 {
@@ -227,8 +197,6 @@ static KRML_NOINLINE uint8_t FStar_UInt8_gte_mask(uint8_t a, uint8_t b)
   uint8_t x_xor_q_ = x_xor_q >> (uint32_t)7U;
   return x_xor_q_ - (uint8_t)1U;
 }
-
-KRML_NOINLINE_END
 
 extern Prims_string FStar_UInt8_to_string(uint8_t uu___);
 

--- a/krmllib/dist/uint128/FStar_UInt_8_16_32_64.h
+++ b/krmllib/dist/uint128/FStar_UInt_8_16_32_64.h
@@ -12,8 +12,6 @@
 #include "krml/internal/types.h"
 #include "krml/internal/target.h"
 
-KRML_NOINLINE_START
-
 static KRML_NOINLINE uint64_t FStar_UInt64_eq_mask(uint64_t a, uint64_t b)
 {
   uint64_t x = a ^ b;
@@ -22,10 +20,6 @@ static KRML_NOINLINE uint64_t FStar_UInt64_eq_mask(uint64_t a, uint64_t b)
   uint64_t xnx = x_or_minus_x >> (uint32_t)63U;
   return xnx - (uint64_t)1U;
 }
-
-KRML_NOINLINE_END
-
-KRML_NOINLINE_START
 
 static KRML_NOINLINE uint64_t FStar_UInt64_gte_mask(uint64_t a, uint64_t b)
 {
@@ -39,8 +33,6 @@ static KRML_NOINLINE uint64_t FStar_UInt64_gte_mask(uint64_t a, uint64_t b)
   uint64_t x_xor_q_ = x_xor_q >> (uint32_t)63U;
   return x_xor_q_ - (uint64_t)1U;
 }
-
-KRML_NOINLINE_END
 
 
 #define __FStar_UInt_8_16_32_64_H_DEFINED

--- a/lib/CStarToC11.ml
+++ b/lib/CStarToC11.ml
@@ -1331,10 +1331,7 @@ let mk_static f d =
     | C.Function (comments, (qs, ts, inline, (None | Some (Static | Extern)), decl_inits), body) ->
         (* We make the function static *and* inline UNLESS the user requested
            NoInline *)
-        let is_noinline = inline = Some C11.NoInline in
-        (if is_noinline then [ Text "KRML_NOINLINE_START" ] else []) @
-        [ C.Function (comments, (qs, ts, promote_inline inline, Some Static, decl_inits), body) ] @
-        (if is_noinline then [ Text "KRML_NOINLINE_END" ] else [])
+        [ C.Function (comments, (qs, ts, promote_inline inline, Some Static, decl_inits), body) ]
     | d ->
         [ d ]
   ) (f d)


### PR DESCRIPTION
This PR simplifies the KRML_NOINLINE fix for masking functions to use the attribute "unused" instead of pragmas.