### PR TITLE
Improve treatment of ignore

### DIFF
--- a/krmllib/dist/generic/FStar_BV.c
+++ b/krmllib/dist/generic/FStar_BV.c
@@ -323,6 +323,19 @@ Prims_list__bool
 }
 
 Prims_list__bool
+*FStar_BV_bvdiv_unsafe(krml_checked_int_t n, Prims_list__bool *a, Prims_list__bool *b)
+{
+  if (FStar_BV_bv2int(n, b) != (krml_checked_int_t)0)
+  {
+    return FStar_BV_bvdiv(n, a, FStar_BV_bv2int(n, b));
+  }
+  else
+  {
+    return FStar_BV_int2bv(n, (krml_checked_int_t)0);
+  }
+}
+
+Prims_list__bool
 *FStar_BV_bvmod(krml_checked_int_t n, Prims_list__bool *a, krml_checked_int_t b)
 {
   return FStar_BV_int2bv(n, FStar_UInt_mod(n, FStar_BV_bv2int(n, a), b));

--- a/krmllib/dist/generic/FStar_BV.h
+++ b/krmllib/dist/generic/FStar_BV.h
@@ -94,6 +94,9 @@ Prims_list__bool
 *FStar_BV_bvdiv(krml_checked_int_t n, Prims_list__bool *a, krml_checked_int_t b);
 
 Prims_list__bool
+*FStar_BV_bvdiv_unsafe(krml_checked_int_t n, Prims_list__bool *a, Prims_list__bool *b);
+
+Prims_list__bool
 *FStar_BV_bvmod(krml_checked_int_t n, Prims_list__bool *a, krml_checked_int_t b);
 
 Prims_list__bool

--- a/krmllib/dist/generic/FStar_Issue.h
+++ b/krmllib/dist/generic/FStar_Issue.h
@@ -9,6 +9,7 @@
 
 #include "FStar_String.h"
 #include "FStar_Bytes.h"
+#include "FStar_BitVector.h"
 #include <inttypes.h>
 #include "krmllib.h"
 #include "krml/internal/compat.h"
@@ -16,7 +17,17 @@
 
 typedef Prims_string FStar_Issue_issue_level_string;
 
-extern Prims_string FStar_Issue_message_of_issue(FStar_Issue_issue i);
+typedef struct Prims_list__FStar_Pprint_document_s Prims_list__FStar_Pprint_document;
+
+typedef struct Prims_list__FStar_Pprint_document_s
+{
+  Prims_list__bool_tags tag;
+  FStar_Pprint_document hd;
+  Prims_list__FStar_Pprint_document *tl;
+}
+Prims_list__FStar_Pprint_document;
+
+extern Prims_list__FStar_Pprint_document *FStar_Issue_message_of_issue(FStar_Issue_issue i);
 
 extern Prims_string FStar_Issue_level_of_issue(FStar_Issue_issue i);
 
@@ -35,10 +46,12 @@ FStar_Issue_range_of_issue(FStar_Issue_issue i);
 
 extern Prims_list__Prims_string *FStar_Issue_context_of_issue(FStar_Issue_issue i);
 
+extern Prims_string FStar_Issue_render_issue(FStar_Issue_issue i);
+
 extern FStar_Issue_issue
-FStar_Issue_mk_issue(
+FStar_Issue_mk_issue_doc(
   Prims_string i,
-  Prims_string msg,
+  Prims_list__FStar_Pprint_document *msg,
   FStar_Pervasives_Native_option__FStar_Range_range range,
   FStar_Pervasives_Native_option__krml_checked_int_t number,
   Prims_list__Prims_string *ctx

--- a/krmllib/dist/generic/FStar_Monotonic_Heap.h
+++ b/krmllib/dist/generic/FStar_Monotonic_Heap.h
@@ -19,6 +19,7 @@ typedef struct FStar_Pervasives_dtuple4_____FStar_Pervasives_Native_option_____b
 {
   FStar_Pervasives_Native_option__Prims_string_tags _2;
   bool _3;
+  void *_4;
 }
 FStar_Pervasives_dtuple4_____FStar_Pervasives_Native_option_____bool_any;
 

--- a/krmllib/dist/generic/libkrmllib.def
+++ b/krmllib/dist/generic/libkrmllib.def
@@ -37,6 +37,7 @@ EXPORTS
   FStar_BV_bvadd
   FStar_BV_bvsub
   FStar_BV_bvdiv
+  FStar_BV_bvdiv_unsafe
   FStar_BV_bvmod
   FStar_BV_bvmul
   FStar_Order_uu___is_Lt

--- a/lib/AstToCFlat.ml
+++ b/lib/AstToCFlat.ml
@@ -723,7 +723,7 @@ and mk_expr (env: env) (locals: locals) (e: expr): locals * CF.expr =
   | EOpen _ ->
       invalid_arg "mk_expr (EOpen)"
 
-  | EApp ({ node = EQualified (["LowStar"; "Ignore"],"ignore"); _ }, [ _ ]) ->
+  | EApp ({ node = ETApp ({ node = EQualified (["LowStar"; "Ignore"],"ignore"); _ }, _); _ }, [ _ ]) ->
       locals, cflat_unit
 
   | EApp ({ node = ETApp ({ node = EQualified (["Lib"; "Memzero0"],"memzero"); _ }, _); _ }, [ dst; len ]) ->

--- a/lib/AstToCStar.ml
+++ b/lib/AstToCStar.ml
@@ -197,6 +197,7 @@ let string_of_return_pos = function
 let whitelisted_lid lid =
   match lid with
   | ["Lib"; "Memzero0"],"memzero" -> true
+  | ["LowStar"; "Ignore"],"ignore" -> true
   | ["Steel"; "SpinLock"],"lock" -> true
   | _ -> false
 

--- a/lib/Builtin.ml
+++ b/lib/Builtin.ml
@@ -244,7 +244,7 @@ let lowstar_buffer: file =
 
 let lowstar_ignore: file =
   "LowStar_Ignore", [
-    mk_val ~flags:Common.[ Macro ] [ "LowStar"; "Ignore" ] "ignore" (TArrow (TAny, TUnit))
+    mk_val ~nvars:1 ~flags:Common.[ Macro ] [ "LowStar"; "Ignore" ] "ignore" (TArrow (TBound 0, TUnit))
   ]
 
 let lowstar_endianness: file =

--- a/lib/CStarToC11.ml
+++ b/lib/CStarToC11.ml
@@ -534,6 +534,7 @@ and mk_stmt m (stmt: stmt): C.stmt list =
       [ Continue ]
 
   | Ignore e ->
+      (* XXX why is this not compiled the same way as mk_ignore? *)
       [ Expr (mk_expr m e) ]
 
   | Decl (binder, BufCreate ((Eternal | Heap), init, size)) ->
@@ -831,7 +832,11 @@ and mk_expr m (e: expr): C.expr =
   | Comma (e1, e2) ->
       Op2 (K.Comma, mk_expr m e1, mk_expr m e2)
 
-  | Call (Qualified ([ "LowStar"; "Ignore" ], "ignore"), [ arg ]) ->
+  | Call (Qualified ([ "LowStar"; "Ignore" ], "ignore"), [ _ ]) ->
+      (* Only one argument because of unit-to-void elimination -- should not happen. *)
+      failwith "`ignore ()` should have been removed earlier on"
+
+  | Call (Qualified ([ "LowStar"; "Ignore" ], "ignore"), [ arg; _ ]) ->
       mk_ignore (mk_expr m arg)
 
   | Call (Qualified ([ "C"; "Nullity" ], s), [ e1 ]) when KString.starts_with s "op_Bang_Star__" ->

--- a/lib/Simplify.ml
+++ b/lib/Simplify.ml
@@ -447,6 +447,18 @@ let remove_uu = object (self)
       ELet (b, e1, e2)
 end
 
+let remove_ignore_unit = object
+
+  inherit [_] map as super
+
+  method! visit_EApp env hd args =
+    match hd.node, args with
+    | ETApp ({ node = EQualified (["LowStar"; "Ignore"], "ignore"); _}, [ TUnit ]), [ { node = EUnit; _ } ] ->
+        EUnit
+    | _ ->
+        super#visit_EApp env hd args
+end
+
 let remove_proj_is = object
 
   inherit [_] map
@@ -1937,6 +1949,7 @@ let simplify0 (files: file list): file list =
   let files = remove_local_function_bindings#visit_files () files in
   let files = count_and_remove_locals#visit_files [] files in
   let files = remove_uu#visit_files () files in
+  let files = remove_ignore_unit#visit_files () files in
   let files = remove_proj_is#visit_files () files in
   let files = combinators#visit_files () files in
   let files = wrapping_arithmetic#visit_files () files in


### PR DESCRIPTION
Relies on previous work to retain type applications further down the compilation pipeline. Also removes a few silly lines from HACL*.