### PR TITLE
Implicit conversions in  fstar_uint128_gcc64.h

### DIFF
--- a/krmllib/c/fstar_uint128_gcc64.h
+++ b/krmllib/c/fstar_uint128_gcc64.h
@@ -110,7 +110,7 @@ inline static uint128_t FStar_UInt128_mul_wide(uint64_t x, uint64_t y) {
 inline static uint128_t FStar_UInt128_eq_mask(uint128_t x, uint128_t y) {
   uint64_t mask =
       FStar_UInt64_eq_mask((uint64_t)(x >> 64), (uint64_t)(y >> 64)) &
-      FStar_UInt64_eq_mask(x, y);
+      FStar_UInt64_eq_mask((uint64_t)x, (uint64_t)y);
   return ((uint128_t)mask) << 64 | mask;
 }
 
@@ -118,7 +118,7 @@ inline static uint128_t FStar_UInt128_gte_mask(uint128_t x, uint128_t y) {
   uint64_t mask =
       (FStar_UInt64_gte_mask(x >> 64, y >> 64) &
        ~(FStar_UInt64_eq_mask(x >> 64, y >> 64))) |
-      (FStar_UInt64_eq_mask(x >> 64, y >> 64) & FStar_UInt64_gte_mask(x, y));
+      (FStar_UInt64_eq_mask(x >> 64, y >> 64) & FStar_UInt64_gte_mask((uint64_t)x, (uint64_t)y));
   return ((uint128_t)mask) << 64 | mask;
 }
 


### PR DESCRIPTION
Should this be done in the msvc version as well?