### PR TITLE
Address long-standing issue with right shift -- fixes #102

### DIFF
--- a/book/AdvancedTopics.rst
+++ b/book/AdvancedTopics.rst
@@ -192,3 +192,14 @@ type (see digression above).
   require any libkrmllib.a; other parts of krmllib do not use this facility,
   meaning that projects like miTLS still link against libkrmllib.a to find
   external symbols (e.g. from ``FStar.Date``)
+
+Assumptions on the C target
+---------------------------
+
+KaRaMeL makes several assumptions regarding the C target environment. Most of
+these are unlikely to be violated in any modern environment.
+
+- The size of `int` is at most 4. This ensures that our compilation strategy for
+  uint8 and uint16 (namely, upcast subexpressions into uint32_t to defeat the
+  promotion to unsigned int, which would lead to UB on overflow) is sound. This
+  strategy may be suboptimal on machines for which `sizeof int < 4`.

--- a/lib/AstToCStar.ml
+++ b/lib/AstToCStar.ml
@@ -228,12 +228,15 @@ let rec unit_to_void env e es extra =
   (https://www.viva64.com/en/t/0012/) and no, we don't intend to run the
   generated C code on a PDP-11.
 
-  A brief recap. In C, if the operands of an arithmetic expression are of a type
-  smaller than int, they are promoted to int and all intermediary computations
-  are performed on `int` before being cast into the destination type. The
-  destination type is known because the arithmetic expression appears underneath
-  an assignment, as an argument to a function call, as the value of a field with
-  a known type, and so on.
+  A brief recap (see [1], [2] for more). In C, if the operands of an arithmetic
+  expression are of a type smaller than int, they are promoted to int and all
+  intermediary computations are performed on `int` before being cast into the
+  destination type. The destination type is known because the arithmetic
+  expression appears underneath an assignment, as an argument to a function
+  call, as the value of a field with a known type, and so on.
+
+  [1]: https://wiki.sei.cmu.edu/confluence/display/c/INT02-C.+Understand+integer+conversion+rules
+  [2]: https://en.cppreference.com/w/c/language/conversion
 
   In Low*, operations are homogenous and the semantics is that every
   subexpression is cast immediately back to its original type.

--- a/lib/PrintC.ml
+++ b/lib/PrintC.ml
@@ -226,7 +226,12 @@ and p_expr' curr = function
   | Literal s ->
       dquote ^^ string s ^^ dquote
   | Constant (w, s) ->
-      string s ^^ if K.is_unsigned w then string "U" else empty
+      let suffix = match w with
+        | UInt64 -> string "ULL"
+        | UInt32 | UInt16 | UInt8 -> string "U"
+        | _ -> empty
+      in
+      string s ^^ suffix
   | Name s ->
       string s
   | Cast (t, e) ->

--- a/test/Shift.fst
+++ b/test/Shift.fst
@@ -1,0 +1,13 @@
+module Shift
+
+open FStar.HyperStack.All
+open FStar.UInt8
+
+inline_for_extraction
+let f #a (x: a): Stack a (requires fun _ -> True) (ensures fun h0 x' h1 -> h0 == h1 /\ x == x') = x
+
+val main: unit -> St C.exit_code
+let main _ =
+  let z = (f 0uy -%^ f 1uy) >>^ f 7ul in
+  match z with
+  | 1uy -> C.EXIT_SUCCESS


### PR DESCRIPTION
After several days and many discarded designs, I think I have found a reasonable way to i) optimize the generation of integer arithmetic constants and computations (hi @franziskuskiefer, @karthikbhargavan, please take a look at HACL branch protz_shift to see the effects of the change), ii) fix the semantics of right-shift (hi @s-zanella, @polubelova), and iii) in the process of doing so, fix integer conversion warnings for right-shifts (there are still spurious warnings in a lot of places in HACL, but at least that one reported on Slack by @franziskuskiefer in FrodoKEM is now gone).

I know that others have encountered #102 in one form or another in the past, so my request to @tahina-pro: can you please take a careful look at this PR and tell me whether you believe this compilation scheme is correct or not? In addition, can you see if this helps get rid of your earlier workarounds?

Thanks!