### PR TITLE
Upcast SizeT since the UZ suffix isn't yet widely available

### DIFF
--- a/lib/CStarToC11.ml
+++ b/lib/CStarToC11.ml
@@ -943,7 +943,7 @@ and mk_expr m (e: expr): C.expr =
 
   | Constant (w, c) ->
       (* See discussion in AstToCStar.ml, around mk_arith. *)
-      if K.is_unsigned w then
+      if K.is_unsigned w && w <> SizeT then
         Constant (w, c)
       else
         (* Not sure what to do with signed integer types. TBD. Mostly trying to


### PR DESCRIPTION
Ideally we would emit UZ but this is C++23 and unclear whether it's in the C standard, even.