### PR TITLE
ci: standalone.Dockerfile: add missing dependencies

### DIFF
--- a/.docker/standalone.Dockerfile
+++ b/.docker/standalone.Dockerfile
@@ -13,7 +13,9 @@ RUN apt-get update && \
       gawk \
       coreutils \
       sudo \
-      opam
+      opam \
+      python3 \
+      python3-distutils
 
 
 # Create a new user and give them sudo rights


### PR DESCRIPTION
Should fix the CI breakage if no F* images are present.