### PR TITLE
Generalization of the "pass by ref" for the case where functions are returning arrays (not pointers)

### DIFF
--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -513,6 +513,12 @@ class ['self] map = object (self: 'self)
     let env = self#extend_many env bs in
     let e = self#visit_expr_w env e in
     DFunction (cc, flags, n, t, lid, bs, e)
+
+  method! visit_ETApp env e ts =
+    let ts = List.map (self#visit_typ_wo env) ts in
+    let env = self#extend_tmany (fst env) (List.length ts) in
+    let e = self#visit_expr_w env e in
+    ETApp (e, ts)
 end
 
 class ['self] iter = object (self: 'self)

--- a/lib/Checker.ml
+++ b/lib/Checker.ml
@@ -1089,6 +1089,12 @@ and subtype env t1 t2 =
   | TAnonymous (Flat [ Some f, (t, _) ]), TAnonymous (Union ts) ->
       List.exists (fun (f', t') -> f = f' && subtype env t t') ts
 
+  | TApp (lid, ts), _ when Hashtbl.mem MonomorphizationState.state (lid, ts) ->
+      subtype env (TQualified (snd (Hashtbl.find MonomorphizationState.state (lid, ts)))) t2
+
+  | _, TApp (lid, ts) when Hashtbl.mem MonomorphizationState.state (lid, ts) ->
+      subtype env t1 (TQualified (snd (Hashtbl.find MonomorphizationState.state (lid, ts))))
+
   | _ ->
       false
 

--- a/lib/Checker.ml
+++ b/lib/Checker.ml
@@ -688,7 +688,7 @@ and infer' env e =
       check env TBool e1;
       let t = infer env e2 in
       if t = TUnit || t = TAny then
-        t (* loops that end in return can be typed with TAny *)
+        TAny (* loops that end in return can be typed with TAny *)
       else
         checker_error env "%a, while loop is neither tany or tunit" ploc env.location
 

--- a/lib/Helpers.ml
+++ b/lib/Helpers.ml
@@ -28,6 +28,7 @@ end
 (* Creating AST nodes *********************************************************)
 
 let uint32 = TInt K.UInt32
+let usize = TInt K.SizeT
 
 let type_of_op op w =
   let open Constant in
@@ -64,6 +65,8 @@ let zerou32 = zero K.UInt32
 let one w = with_type (TInt w) (EConstant (w, "1"))
 let oneu32 = one K.UInt32
 
+let zero_usize = zero K.SizeT
+
 let pwild = with_type TAny PWild
 
 let mk_op op w =
@@ -80,6 +83,9 @@ let mk_lt w finish =
 let mk_lt32 =
   mk_lt K.UInt32
 
+let mk_lt_usize =
+  mk_lt K.SizeT
+
 (* @0 <- @0 + 1ul *)
 let mk_incr w =
   let t = TInt w in
@@ -91,6 +97,8 @@ let mk_incr w =
         one w ]))))
 
 let mk_incr32 = mk_incr K.UInt32
+
+let mk_incr_usize = mk_incr K.SizeT
 
 let mk_neq e1 e2 =
   with_type TBool (EApp (mk_op K.Neq K.UInt32, [ e1; e2 ]))

--- a/lib/MonomorphizationState.ml
+++ b/lib/MonomorphizationState.ml
@@ -1,0 +1,4 @@
+open Ast
+type node = lident * typ list
+type color = Gray | Black
+let state: (node, color * lident) Hashtbl.t = Hashtbl.create 41

--- a/lib/PrintC.ml
+++ b/lib/PrintC.ml
@@ -167,9 +167,9 @@ and prec_of_op1 op =
 and is_prefix op =
   let open Constant in
   match op with
-  | PreDecr | PreIncr | Not | BNot -> true
+  | PreDecr | PreIncr | Not | BNot | Neg -> true
   | PostDecr | PostIncr -> false
-  | _ -> raise (Invalid_argument "is_prefix")
+  | _ -> raise (Invalid_argument ("is_prefix " ^ show_op op))
 
 (* The precedence level [curr] is the maximum precedence the current node should
  * have. If it doesn't, then it should be parenthesized. Lower numbers bind

--- a/lib/Simplify.ml
+++ b/lib/Simplify.ml
@@ -1066,7 +1066,7 @@ and hoist_expr loc pos e =
       (* We now allow IfThenElse nodes directly under IfThenElse, on the basis
        * that the outer IfThenElse is properly positioned under a let-binding.
        * let_if_to_assign will know how to deal with this. *)
-      if pos = UnderStmtLet || pos = UnderConditional || Options.rust () then
+      if pos = UnderStmtLet || pos = UnderConditional then
         lhs1, mk (EIfThenElse (e1, e2, e3))
       else
         let b, body, cont = mk_named_binding "ite" t (EIfThenElse (e1, e2, e3)) in

--- a/lib/Simplify.ml
+++ b/lib/Simplify.ml
@@ -1066,7 +1066,7 @@ and hoist_expr loc pos e =
       (* We now allow IfThenElse nodes directly under IfThenElse, on the basis
        * that the outer IfThenElse is properly positioned under a let-binding.
        * let_if_to_assign will know how to deal with this. *)
-      if pos = UnderStmtLet || pos = UnderConditional then
+      if pos = UnderStmtLet || pos = UnderConditional || Options.rust () then
         lhs1, mk (EIfThenElse (e1, e2, e3))
       else
         let b, body, cont = mk_named_binding "ite" t (EIfThenElse (e1, e2, e3)) in

--- a/lib/Structs.ml
+++ b/lib/Structs.ml
@@ -206,7 +206,7 @@ let pass_by_ref (should_rewrite: _ -> policy) = object (self)
     let ret, binders, ret_atom, ret_is_array =
       if ret_is_struct then
         let ret_is_array = Helpers.is_array ret in
-        let ret_binder, ret_atom = Helpers.mk_binding "ret" (if ret_is_array then ret else TBuf (ret, false)) in
+        let ret_binder, ret_atom = Helpers.mk_binding ~mut:true "ret" (if ret_is_array then ret else TBuf (ret, false)) in
         TUnit, binders @ [ ret_binder ], Some ret_atom, ret_is_array
       else
         ret, binders, None, false

--- a/lib/Structs.ml
+++ b/lib/Structs.ml
@@ -72,7 +72,7 @@ let analyze_function_type policy t =
   match t with
   | TArrow _ as t ->
       let ret, args = Helpers.flatten_arrow t in
-      policy ret, List.map policy args
+      (if Helpers.is_array ret then Always else policy ret), List.map policy args
   | t ->
       Warn.fatal_error "analyze_function_type: %a is not a function type" ptyp t
 
@@ -155,11 +155,19 @@ let pass_by_ref (should_rewrite: _ -> policy) = object (self)
     ) ([], []) (List.combine args args_are_structs) in
     let args = List.rev args in
 
+    (* Arrays are passed by reference in C *)
+    let maybe_addrof e =
+      if Helpers.is_array e.typ then
+        e
+      else
+        with_type (TBuf (t, false)) (EAddrOf e)
+    in
+
     (* The three behaviors described above. *)
     if ret_is_struct <> Never then
       match dest with
       | Some dest ->
-          let args = args @ [ with_type (TBuf (t, false)) (EAddrOf dest) ] in
+          let args = args @ [ maybe_addrof dest ] in
           Helpers.nest bs t (with_type TUnit (EApp (e, args)))
       | None ->
           (* Indicate to the following phase that this is going to be mutated
@@ -167,7 +175,7 @@ let pass_by_ref (should_rewrite: _ -> policy) = object (self)
              mut in the internal AST) *)
           let x, dest = Helpers.mk_binding ~mut:true "ret" t in
           let bs = (x, with_type TAny EAny) :: bs in
-          let args = args @ [ with_type (TBuf (t, false)) (EAddrOf dest) ] in
+          let args = args @ [ maybe_addrof dest ] in
           Helpers.nest bs t (with_type t (ESequence [
             with_type TUnit (EApp (e, args));
             dest]))
@@ -183,7 +191,7 @@ let pass_by_ref (should_rewrite: _ -> policy) = object (self)
     (* Step 1: open all the binders *)
     let binders, body = DeBruijn.open_binders binders body in
 
-    let ret_is_struct = should_rewrite ret <> Never in
+    let ret_is_struct = should_rewrite ret <> Never || Helpers.is_array ret in
     let args_are_structs = List.map (fun x -> should_rewrite x.typ <> Never) binders in
 
     (* Step 2: rewrite the types of the arguments to take pointers to structs *)
@@ -195,12 +203,13 @@ let pass_by_ref (should_rewrite: _ -> policy) = object (self)
     ) binders args_are_structs in
 
     (* Step 3: add an extra argument in case the return type is a struct, too *)
-    let ret, binders, ret_atom =
+    let ret, binders, ret_atom, ret_is_array =
       if ret_is_struct then
-        let ret_binder, ret_atom = Helpers.mk_binding "ret" (TBuf (ret, false)) in
-        TUnit, binders @ [ ret_binder ], Some ret_atom
+        let ret_is_array = Helpers.is_array ret in
+        let ret_binder, ret_atom = Helpers.mk_binding "ret" (if ret_is_array then ret else TBuf (ret, false)) in
+        TUnit, binders @ [ ret_binder ], Some ret_atom, ret_is_array
       else
-        ret, binders, None
+        ret, binders, None, false
     in
 
     (* ... and remember the corresponding atoms: every occurrence becomes a
@@ -217,7 +226,10 @@ let pass_by_ref (should_rewrite: _ -> policy) = object (self)
     (* Step 4: if the function now takes an extra argument for the output struct. *)
     let body =
       if ret_is_struct then
-        with_type TUnit (EBufWrite (Option.must ret_atom, Helpers.zerou32, body))
+        if ret_is_array then
+          with_type TUnit (EAssign (Option.must ret_atom, body))
+        else
+          with_type TUnit (EBufWrite (Option.must ret_atom, Helpers.zerou32, body))
       else
         body
     in


### PR DESCRIPTION
Rust makes a proper distinction between arrays and pointers, and functions in Rust can return arrays (by value). This can of course be optimized into a caller allocating space for the array (known at compile-time) and the callee copying its return value into the destination address.

There was already a phase for that in krml (used for mitls, a long time ago, but also for the wasm backend) so it was mostly a matter of tweaking it.