### PR TITLE
Use Dune 3.5

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,4 +1,4 @@
-(lang dune 3.7)
+(lang dune 3.5)
 (name karamel)
 (using menhir 2.0)
 


### PR DESCRIPTION
PR #364 moved the Dune minimal version requirement in `dune-project` to 3.7, but this prevents Karamel from being built on Windows with fdopen's deprecated repository, which only supports Dune up to 3.5, and which is currently the only known method to build native Windows executables for Everest components.

This PR sets the requirement to Dune 3.5. It works at least on my Windows machine.
