### PR TITLE
Cleanup the `KList` module

### DIFF
--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -625,7 +625,7 @@ end
 (** More helpers *)
 
 let filter_decls f files =
-  List.map (fun (file, decls) -> file, KList.filter_map f decls) files
+  List.map (fun (file, decls) -> file, List.filter_map f decls) files
 
 let map_decls f files =
   List.map (fun (file, decls) -> file, List.map f decls) files

--- a/lib/AstToCFlat.ml
+++ b/lib/AstToCFlat.ml
@@ -538,7 +538,7 @@ let write_static (env: env) (lid: lident) (e: expr): string * CFlat.expr list =
         []
     | EFlat fields ->
         let layout = Option.get (layout_of env e) in
-        KList.map_flatten (fun (fname, e) ->
+        List.concat_map (fun (fname, e) ->
           let fname = Option.get fname in
           let fofs = fst (List.assoc fname layout.fields) in
           write_scalar dst (ofs + fofs) e

--- a/lib/AstToCFlat.ml
+++ b/lib/AstToCFlat.ml
@@ -1019,7 +1019,7 @@ let mk_wrapper orig_name n_args locals =
   let args, locals = KList.split n_args locals in
   let body =
     CF.CastI64ToPacked (
-      CF.CallFunc (orig_name, KList.make (List.length args) (fun i -> CF.Var i))
+      CF.CallFunc (orig_name, List.init (List.length args) (fun i -> CF.Var i))
     )
   in
   CF.(Function { name; args; ret; locals; body; public = true })

--- a/lib/Builtin.ml
+++ b/lib/Builtin.ml
@@ -375,7 +375,7 @@ let make_abstract_function_or_global = function
  * - lets are replaced by vals
  * - but we keep the gte_mask and eq_mask functions *)
 let make_abstract (name, decls) =
-  name, KList.filter_map (function
+  name, List.filter_map (function
     | DType (_, _, _, Abbrev _) as t ->
         Some t
     | DType _ ->
@@ -393,7 +393,7 @@ let make_abstract (name, decls) =
 (* Transforms an F* module that contains a model into a set of "assume val" that
  * will generate proper "extern" declarations in C. *)
 let make_library (name, decls) =
-  name, KList.filter_map make_abstract_function_or_global decls
+  name, List.filter_map make_abstract_function_or_global decls
 
 let is_model name =
   let is_machine_integer name =

--- a/lib/Bundle.ml
+++ b/lib/Bundle.ml
@@ -72,7 +72,7 @@ let pattern_matches (p: pat) (m: string) =
 
 (* For generating the filename. NOT for pretty-printing. *)
 let bundle_filename (api, patterns, attrs) =
-  match KList.find_opt (function Rename s -> Some s | _ -> None) attrs with
+  match List.find_map (function Rename s -> Some s | _ -> None) attrs with
   | Some s ->
       s
   | _ ->

--- a/lib/Bundle.ml
+++ b/lib/Bundle.ml
@@ -78,7 +78,7 @@ let bundle_filename (api, patterns, attrs) =
   | _ ->
       match api with
       | [] ->
-          String.concat "_" (KList.map_flatten (function
+          String.concat "_" (List.concat_map (function
             | Module m -> m
             | Prefix p -> p
           ) patterns)

--- a/lib/CFlatToWasm.ml
+++ b/lib/CFlatToWasm.ml
@@ -1228,7 +1228,7 @@ let mk_module (name, decls): (string * W.Ast.module_) =
   (* Generate types for the function declarations. Re-establish the invariant
    * that the function at index i in the function index space has type i in the
    * types index space. *)
-  let types = imported_types @ KList.filter_map (function
+  let types = imported_types @ List.filter_map (function
     | Function f ->
         Some (mk_func_type f)
     | _ ->
@@ -1237,7 +1237,7 @@ let mk_module (name, decls): (string * W.Ast.module_) =
 
   (* Compile the functions. We assume all of the required functions have been
      inserted in env.funcs (ibid. globals) via the first pass. *)
-  let funcs = KList.filter_map (function
+  let funcs = List.filter_map (function
     | Function f ->
         begin try Some (mk_func (locate env (In f.name)) f) with
         | e ->
@@ -1316,7 +1316,7 @@ let mk_module (name, decls): (string * W.Ast.module_) =
   })] in
 
   (* Export all of the current module's functions & globals. *)
-  let exports = KList.filter_map (function
+  let exports = List.filter_map (function
     | Function { public; name; _ } when public ->
         Some (dummy_phrase W.Ast.({
           name = name_of_string name;

--- a/lib/CFlatToWasm.ml
+++ b/lib/CFlatToWasm.ml
@@ -906,8 +906,8 @@ and mk_expr env (e: expr): W.Ast.instr list =
       [ dummy_phrase W.Ast.Unreachable ]
 
   | Switch (e, branches, default, s) ->
-      let vmax = KList.max (List.map (fun (c, _) -> Z.of_string (snd c)) branches) in
-      let vmin = KList.min (List.map (fun (c, _) -> Z.of_string (snd c)) branches) in
+      let vmax = KList.reduce max (List.map (fun (c, _) -> Z.of_string (snd c)) branches) in
+      let vmin = KList.reduce min (List.map (fun (c, _) -> Z.of_string (snd c)) branches) in
       if Z.( gt vmax ~$20 || lt vmin ~$0 ) then
         failwith "TODO: in AstToCFlat, don't pick Switch for matches on integers!";
 

--- a/lib/CFlatToWasm.ml
+++ b/lib/CFlatToWasm.ml
@@ -779,7 +779,7 @@ and mk_expr env (e: expr): W.Ast.instr list =
       mk_expr env (CallFunc ("store64_le", [ e1; CallFunc ("WasmSupport_betole64", [ e2 ])]))
 
   | CallFunc (name, es) ->
-      KList.map_flatten (mk_expr env) es @
+      List.concat_map (mk_expr env) es @
       [ dummy_phrase (W.Ast.Call (mk_var (find_func env name))) ]
 
   | BufCreate (Common.Stack, n_elts, elt_size) ->

--- a/lib/CStarToC11.ml
+++ b/lib/CStarToC11.ml
@@ -1026,7 +1026,7 @@ and mk_type m t =
   mk_spec_and_declarator m "" t
 
 let mk_comments =
-  KList.filter_map (function
+  List.filter_map (function
     | Comment c when c <> "" ->
         Some c
     | _ ->
@@ -1038,15 +1038,15 @@ let wrap_verbatim lid flags d =
     [ Text (KPrint.bsprintf "/* SNIPPET_START: %s */" lid) ]
   else
     []) @
-  KList.filter_map (function
+  List.filter_map (function
     | Prologue s -> Some (Text s)
     | _ -> None
   ) flags @
-  KList.filter_map (function
+  List.filter_map (function
     | Deprecated s -> Some (Text (KPrint.bsprintf "KRML_DEPRECATED(\"%s\")" s))
     | _ -> None
   ) flags @
-  [ d ] @ KList.filter_map (function
+  [ d ] @ List.filter_map (function
     | Epilogue s -> Some (Text s)
     | _ -> None
   ) flags @

--- a/lib/CStarToC11.ml
+++ b/lib/CStarToC11.ml
@@ -1230,7 +1230,7 @@ let mk_type_or_external m (w: where) ?(is_inline_static=false) (d: decl): C.decl
         let missing_names = List.length ts - List.length pp in
         let arg_names =
           if missing_names >= 0 then
-            pp @ KList.make missing_names (fun i -> KPrint.bsprintf "x%d" i)
+            pp @ List.init missing_names (fun i -> KPrint.bsprintf "x%d" i)
           else
             (* For functions that take a single unit argument, the name of the
              * unit is gone. *)

--- a/lib/Checker.ml
+++ b/lib/Checker.ml
@@ -237,7 +237,7 @@ and check_fields_opt env fieldexprs fieldtyps =
     checker_error env "some fields are superfluous (expr) in %a" pexpr (with_unit (EFlat fieldexprs));
   List.iter (fun (field, expr) ->
     let field = Option.get field in
-    let t, _ = KList.assoc_opt field fieldtyps in
+    let t, _ = List.assoc (Some field) fieldtyps in
     check env t expr
   ) fieldexprs
 
@@ -245,7 +245,7 @@ and check_fieldpats env fieldexprs fieldtyps =
   if List.length fieldexprs > List.length fieldtyps then
     checker_error env "some fields are superfluous (pat) in %a" ppat (with_unit (PRecord fieldexprs));
   List.iter (fun (field, expr) ->
-    let t, _ = KList.assoc_opt field fieldtyps in
+    let t, _ = List.assoc (Some field) fieldtyps in
     check_pat env t expr
   ) fieldexprs
 
@@ -813,7 +813,7 @@ and find_field_from_def env def field =
     | Union fields ->
         List.assoc field fields, true (* owing to nocompound-literals which may mutate it *)
     | Flat fields ->
-        KList.assoc_opt field fields
+        List.assoc (Some field) fields
     | _ ->
         raise Not_found
   end with Not_found ->

--- a/lib/Checker.ml
+++ b/lib/Checker.ml
@@ -158,7 +158,7 @@ let rec check_everything ?warn files: bool * file list =
 and check_program env r (name, decls) =
   let env = locate env (File name) in
   let by_lid = Hashtbl.create 41 in
-  let decls = KList.filter_map (fun d ->
+  let decls = List.filter_map (fun d ->
     try
       check_decl env d;
       Some d

--- a/lib/DataTypes.ml
+++ b/lib/DataTypes.ml
@@ -980,7 +980,7 @@ let compile_all_matches (map, enums) = object (self)
 
   method private tag_and_val_type lid branches =
     let tags = List.map (fun (cons, _fields) -> mk_tag_lid lid cons) branches in
-    let structs = KList.filter_map (fun (cons, fields) ->
+    let structs = List.filter_map (fun (cons, fields) ->
       let fields = List.map (fun (f, t) -> Some f, t) fields in
       match List.length fields with
       | 0 ->

--- a/lib/DataTypes.ml
+++ b/lib/DataTypes.ml
@@ -332,7 +332,7 @@ let compile_simple_matches (map, enums) = object(self)
 
   method! visit_file _ file =
     let name, decls = file in
-    name, KList.map_flatten (fun d ->
+    name, List.concat_map (fun d ->
       let d = self#visit_decl () d in
       let new_decls = !pending in
       pending := [];

--- a/lib/Diagnostics.ml
+++ b/lib/Diagnostics.ml
@@ -26,14 +26,14 @@ let types_depth files =
     | Abbrev t ->
         depth_of_type p t
     | Flat fields ->
-        incr (KList.max (List.map (fun (f, (t, _)) -> depth_of_type (Option.get f :: p) t) fields))
+        incr (KList.reduce max (List.map (fun (f, (t, _)) -> depth_of_type (Option.get f :: p) t) fields))
     | Forward _
     | Variant _ ->
         failwith "impossible"
     | Enum _ ->
         0, List.rev p
     | Union fields ->
-        incr (KList.max (List.map (fun (f, t) -> depth_of_type (f :: p) t) fields))
+        incr (KList.reduce max (List.map (fun (f, t) -> depth_of_type (f :: p) t) fields))
 
   and depth_of_type p t =
     match t with

--- a/lib/GenCtypes.ml
+++ b/lib/GenCtypes.ml
@@ -515,7 +515,7 @@ let mk_ocaml_bindings
 
   (** In a third phase, we collect the generated declarations, and turn them
    * into full-fledged OCaml modules. *)
-  KList.filter_map (fun (name, _) ->
+  List.filter_map (fun (name, _) ->
     match Hashtbl.find_opt ocaml_decls name with
     | None -> None
     | Some decls ->

--- a/lib/GenCtypes.ml
+++ b/lib/GenCtypes.ml
@@ -221,7 +221,7 @@ and mk_struct_decl ?(sealed=true) m (k: structured) (name: A.lident) fields: str
   in
   let type_decl = Str.type_ Recursive [Type.mk ?manifest:(Some tm) (mk_sym unqual_name)] in
   let seal_decl = mk_decl (Pat.any ()) (mk_app (exp_ident "seal") [exp_ident unqual_name]) in
-  [type_decl; ctypes_structure] @ (KList.map_flatten (mk_field false) fields) @ (if sealed then [seal_decl] else [])
+  [type_decl; ctypes_structure] @ (List.concat_map (mk_field false) fields) @ (if sealed then [seal_decl] else [])
 
 and mk_typedef m name typ =
   let type_const = match typ with
@@ -315,7 +315,7 @@ let mk_include name =
 
 let mk_ocaml_bind deps decls =
   let open_f = Str.open_ (Opn.mk ?override:(Some Fresh) (Mod.ident (mk_ident "F"))) in
-  let includes = KList.map_flatten mk_include deps in
+  let includes = List.concat_map mk_include deps in
   let module_exp = Mod.mk (Pmod_structure (open_f::(includes@decls))) in
   let functor_type = Mty.mk (Pmty_ident (mk_ident "Cstubs.FOREIGN")) in
   let functor_exp = Mod.functor_ (Named (mk_sym_opt "F", functor_type)) module_exp in
@@ -507,7 +507,7 @@ let mk_ocaml_bindings
   let transitive_deps = Hashtbl.create 41 in
   List.iter (fun (name, _) ->
     let deps = try Hashtbl.find ocaml_deps name with Not_found -> [] in
-    let deps = KList.map_flatten (fun x ->
+    let deps = List.concat_map (fun x ->
       Hashtbl.find transitive_deps x @ [ x ]
     ) deps in
     Hashtbl.add transitive_deps name (remove_duplicates deps)

--- a/lib/GlobalNames.ml
+++ b/lib/GlobalNames.ml
@@ -190,7 +190,7 @@ let bundle_matches (apis, patterns, _) lid =
   List.exists (fun p -> Helpers.pattern_matches p lid) patterns
 
 let rename_prefix lid =
-  KList.find_opt (fun b ->
+  List.find_map (fun b ->
     if List.mem Bundle.RenamePrefix (Bundle.attrs_of_bundle b) && bundle_matches b lid then
       Some (Bundle.bundle_filename b)
     else

--- a/lib/InputAst.ml
+++ b/lib/InputAst.ml
@@ -194,7 +194,7 @@ let read_file (f: string): file list =
       f version current_version);
   files
 
-let read_files = KList.map_flatten read_file
+let read_files = List.concat_map read_file
 
 let write_file (files: file list) (f: string): unit =
   with_open_out_bin f (fun oc ->

--- a/lib/InputAstToAst.ml
+++ b/lib/InputAstToAst.ml
@@ -18,9 +18,9 @@ let rec binders_of_pat p =
       [ b ]
   | PTuple ps
   | PCons (_, ps) ->
-      KList.map_flatten binders_of_pat ps
+      List.concat_map binders_of_pat ps
   | PRecord fields ->
-      KList.map_flatten binders_of_pat (snd (List.split fields))
+      List.concat_map binders_of_pat (snd (List.split fields))
   | PConstant _
   | PUnit
   | PBool _ ->

--- a/lib/Monomorphization.ml
+++ b/lib/Monomorphization.ml
@@ -253,7 +253,7 @@ let monomorphize_data_types map = object(self)
   method! visit_file _ file =
     let name, decls = file in
     current_file <- name;
-    name, KList.map_flatten (fun d ->
+    name, List.concat_map (fun d ->
       if Options.debug "data-types-traversal" then
         KPrint.bprintf "decl %a\n" plid (lid_of_decl d);
       match d with
@@ -423,7 +423,7 @@ let functions files =
     method! visit_file _ file =
       let file_name, decls = file in
       current_file <- file_name;
-      file_name, KList.map_flatten (function
+      file_name, List.concat_map (function
         | DFunction (cc, flags, n, ret, name, binders, body) ->
             if Hashtbl.mem map name then
               []
@@ -540,7 +540,7 @@ let equalities files =
     method! visit_file env file =
       let file_name, decls = file in
       current_file <- file_name;
-      file_name, KList.map_flatten (fun d ->
+      file_name, List.concat_map (fun d ->
         let d = self#visit_decl env d in
         let equalities = Gen.clear () in
         let equalities = List.map (function

--- a/lib/PrintAst.ml
+++ b/lib/PrintAst.ml
@@ -47,7 +47,7 @@ let rec print_decl = function
       print_flags flags ^^ langle ^^ int n ^^ rangle ^^ print_typ typ ^^ space ^^ string (string_of_lident name) ^^ space ^^ equals ^/^ nest 2 (print_expr expr)
 
   | DType (name, flags, n, def) ->
-      let args = KList.make n (fun i -> string ("t" ^ string_of_int i)) in
+      let args = List.init n (fun i -> string ("t" ^ string_of_int i)) in
       let args = separate space args in
       group (string "type" ^/^ print_flags flags ^/^ string (string_of_lident name) ^/^ args ^/^ equals) ^^
       jump (print_type_def def)

--- a/lib/PrintAst.ml
+++ b/lib/PrintAst.ml
@@ -53,7 +53,7 @@ let rec print_decl = function
       jump (print_type_def def)
 
 and print_comment flags =
-  match KList.find_opt (function Comment c -> Some c | _ -> None) flags with
+  match List.find_map (function Comment c -> Some c | _ -> None) flags with
   | Some c ->
       string "(*" ^^ string c ^^ string "*)" ^^ hardline
   | None ->

--- a/lib/Simplify.ml
+++ b/lib/Simplify.ml
@@ -214,7 +214,7 @@ let unused private_count_table lid ts (i: int) =
     List.nth ts i = TUnit
   in
   unused_i i &&
-  implies (i = 0) (List.exists not (KList.make (List.length ts) unused_i))
+  implies (i = 0) (List.exists not (List.init (List.length ts) unused_i))
 
 let remove_unused_parameters = object (self)
   inherit [_] map
@@ -243,7 +243,7 @@ let remove_unused_parameters = object (self)
         DeBruijn.subst eunit (n_binders - 1 - i) body
       end else
         body
-    ) body (KList.make n_binders (fun i -> i)) in
+    ) body (List.init n_binders (fun i -> i)) in
     let binders = KList.filter_mapi (fun i b -> if unused i then None else Some b) binders in
     DFunction (cc, flags, n, ret, name, binders, body)
 
@@ -329,7 +329,7 @@ let remove_unused_parameters = object (self)
     if List.length es <= List.length ts then
 
       (* Transform the type of the head *)
-      let used = KList.make (List.length ts) (fun i -> not (unused i)) in
+      let used = List.init (List.length ts) (fun i -> not (unused i)) in
       let ts = KList.filter_mask used ts in
       let ts = List.map (self#visit_typ (parameter_table, 0)) ts in
       let e = { e with typ = fold_arrow ts t } in

--- a/lib/SimplifyMerge.ml
+++ b/lib/SimplifyMerge.ml
@@ -142,7 +142,7 @@ let rec merge' (env: env) (u: S.t) (e: expr): S.t * S.t * expr =
               (* If in prefix mode, must find a common prefix *)
               (Options.(!merge_variables <> Prefix) || common_prefix 0 i b.node.name > 0)
             in
-            KList.find_opt (fun (x, (t, h, i)) -> if fits x t h i then Some (x, i) else None) env
+            List.find_map (fun (x, (t, h, i)) -> if fits x t h i then Some (x, i) else None) env
       in
 
       (* For later *)

--- a/lib/Structs.ml
+++ b/lib/Structs.ml
@@ -436,7 +436,7 @@ let pass_by_ref files =
     | TAnonymous (Flat fs) ->
         List.map (fun (_, (t, _)) -> t) fs
     | TAnonymous (Union fs) ->
-        KList.map_flatten (fun f -> fields (snd f)) fs
+        List.concat_map (fun f -> fields (snd f)) fs
     | _ ->
         []
   in

--- a/lib/Structs.ml
+++ b/lib/Structs.ml
@@ -214,7 +214,7 @@ let pass_by_ref (should_rewrite: _ -> policy) = object (self)
 
     (* ... and remember the corresponding atoms: every occurrence becomes a
      * dereference. *)
-    let to_be_starred = KList.filter_map (fun (binder, is_struct) ->
+    let to_be_starred = List.filter_map (fun (binder, is_struct) ->
       if is_struct then
         Some binder.node.atom
       else

--- a/lib/lib/KList.ml
+++ b/lib/lib/KList.ml
@@ -47,17 +47,6 @@ let index p l =
   in
   index 0 l
 
-let assoc_opt k l =
-  begin match List.find_map (function
-    | Some k', v when k' = k ->
-        Some v
-    | _ ->
-        None
-  ) l with
-  | Some v -> v
-  | None -> raise Not_found
-  end
-
 let split i l =
   let rec split acc i l =
     if i = 0 then

--- a/lib/lib/KList.ml
+++ b/lib/lib/KList.ml
@@ -25,14 +25,8 @@ let rec filter_mask mask l =
   | _ ->
       invalid_arg "filter_mask"
 
-let fold_lefti f init l =
-  let rec fold_lefti i acc = function
-    | hd :: tl ->
-        fold_lefti (i + 1) (f i acc hd) tl
-    | [] ->
-        acc
-  in
-  fold_lefti 0 init l
+let fold_lefti f s l =
+  snd @@ List.fold_left (fun (i, s) x -> (i + 1, f i s x)) (0, s) l
 
 (* NOTE: OCaml 5.1 introduces {!Stdlib.List.find_index} which is [index] except
    that it returns an option. *)

--- a/lib/lib/KList.ml
+++ b/lib/lib/KList.ml
@@ -34,17 +34,6 @@ let fold_lefti f init l =
   in
   fold_lefti 0 init l
 
-let make n f =
-  if n < 0 then
-    invalid_arg "KList.make";
-  let rec make acc n f =
-    if n = 0 then
-      acc
-    else
-      make (f (n - 1) :: acc) (n - 1) f
-  in
-  make [] n f
-
 let find_opt f l =
   let rec find = function
     | [] ->

--- a/lib/lib/KList.ml
+++ b/lib/lib/KList.ml
@@ -59,8 +59,10 @@ let split_at_last l =
   let all_but_last, last = split (List.length l - 1) l in
   all_but_last, List.hd last
 
-let last l =
-  snd (split_at_last l)
+let rec last = function
+  | [] -> failwith "KList.last"
+  | [x] -> x
+  | _ :: l -> last l
 
 let reduce f l =
   List.fold_left f (List.hd l) (List.tl l)

--- a/lib/lib/KList.ml
+++ b/lib/lib/KList.ml
@@ -34,6 +34,8 @@ let fold_lefti f init l =
   in
   fold_lefti 0 init l
 
+(* NOTE: OCaml 5.1 introduces {!Stdlib.List.find_index} which is [index] except
+   that it returns an option. *)
 let index p l =
   let rec index i l =
     match l with
@@ -74,6 +76,7 @@ let one l =
   | [ x ] -> x
   | _ -> invalid_arg ("one: argument is of length " ^ string_of_int (List.length l))
 
+(* NOTE: provided by {!Stdlib.List} in OCaml 5.1. *)
 let is_empty = function
   | [] -> true
   | _ -> false

--- a/lib/lib/KList.ml
+++ b/lib/lib/KList.ml
@@ -74,20 +74,6 @@ let one l =
   | [ x ] -> x
   | _ -> invalid_arg ("one: argument is of length " ^ string_of_int (List.length l))
 
-let max l =
-  if List.length l = 0 then
-    invalid_arg "max";
-  let max = ref (List.hd l) in
-  List.iter (fun x -> if x > !max then max := x) (List.tl l);
-  !max
-
-let min l =
-  if List.length l = 0 then
-    invalid_arg "min";
-  let min = ref (List.hd l) in
-  List.iter (fun x -> if x < !min then min := x) (List.tl l);
-  !min
-
 let is_empty = function
   | [] -> true
   | _ -> false

--- a/lib/lib/KList.ml
+++ b/lib/lib/KList.ml
@@ -12,18 +12,7 @@ let rec filter_mapi i f l =
 let filter_mapi f l =
   filter_mapi 0 f l
 
-let rec filter_map f l =
-  match l with
-  | [] ->
-      []
-  | x :: l ->
-      match f x with
-      | Some x ->
-          x :: filter_map f l
-      | None ->
-          filter_map f l
-
-let filter_some l = filter_map (fun x -> x) l
+let filter_some l = List.filter_map Fun.id l
 
 let rec filter_mask mask l =
   match mask, l with

--- a/lib/lib/KList.ml
+++ b/lib/lib/KList.ml
@@ -34,19 +34,6 @@ let fold_lefti f init l =
   in
   fold_lefti 0 init l
 
-let find_opt f l =
-  let rec find = function
-    | [] ->
-        None
-    | hd :: tl ->
-        match f hd with
-        | Some x ->
-            Some x
-        | None ->
-            find tl
-  in
-  find l
-
 let index p l =
   let rec index i l =
     match l with
@@ -61,7 +48,7 @@ let index p l =
   index 0 l
 
 let assoc_opt k l =
-  begin match find_opt (function
+  begin match List.find_map (function
     | Some k', v when k' = k ->
         Some v
     | _ ->

--- a/lib/lib/KList.ml
+++ b/lib/lib/KList.ml
@@ -25,9 +25,6 @@ let rec filter_mask mask l =
   | _ ->
       invalid_arg "filter_mask"
 
-let map_flatten f l =
-  List.flatten (List.map f l)
-
 let fold_lefti f init l =
   let rec fold_lefti i acc = function
     | hd :: tl ->

--- a/src/Karamel.ml
+++ b/src/Karamel.ml
@@ -160,9 +160,9 @@ where [hack.h] contains [#define WasmSupport_check_buffer_size(X)].
 Supported options:|}
     Sys.argv.(0)
     !Options.warn_error
-    (String.concat " " (KList.map_flatten (fun b ->
+    (String.concat " " (List.concat_map (fun b ->
       [ "-bundle"; Bundle.string_of_bundle b ]
-    ) !Options.bundle @ KList.map_flatten (fun p ->
+    ) !Options.bundle @ List.concat_map (fun p ->
       [ "-drop"; Bundle.string_of_pattern p ]
     ) !Options.drop))
     (p "gcc")


### PR DESCRIPTION
This PR cleans up the `KList` module by using newly-introduced `Stdlib.List` utilities:

- `KList.filter_map` is `Stdlib.List.filter_map`
- `KList.map_flatten` is `Stdlib.List.concat_map`
- `KList.make` is `Stdlib.List.init` **except for the side-effects** (I think this is fine but you might want to check this.)
- `KList.find_opt` is `Stdlib.List.find_map`
- `KList.assoc_opt` is `fun k -> Stdlib.List.assoc (Some k)`

Additionally:

- We get rid of `KList.max` and `KList.min` which are easily written using the already-existing `KList.reduce`.
- Some functions will become available in OCaml 5.1 and are commented as such to help future cleanup.
- We rewrite `KList.fold_lefti` as a special case of `List.fold_left`, hopefully making it more readable.
- We rewrite `KList.last` as a recursive function to make it more performant.

The commits are independent and I will happily revert/remove any commit that you don't find useful.