### PR TITLE
remove backtracking in `reduce_full_match`

### DIFF
--- a/test/MatchNested.fst
+++ b/test/MatchNested.fst
@@ -1,0 +1,15 @@
+(* Pathological test for accidentally-exponential backtracking in match-reduction. *)
+module MatchNested
+
+inline_for_extraction
+let swap (#a #b: eqtype) (ab: (a & b)): (b & a) =
+  match ab with
+  | (a, b) -> (b, a)
+
+let match_nested (r: (int & int)): (int & int) =
+  (swap (swap (swap (swap (swap (swap (swap (swap (swap (swap (swap (swap (swap (swap (swap (swap 
+  (swap (swap (swap (swap (swap (swap (swap (swap (swap (swap (swap (swap (swap (swap (swap (swap 
+  (swap (swap (swap (swap (swap (swap (swap (swap (swap (swap (swap (swap (swap (swap (swap (swap
+  (swap r)))))))))))))))))))))))))))))))))))))))))))))))))
+
+let main () = 0l


### PR DESCRIPTION
this PR (hopefully) addresses a performance / non-termination problem I was having.

I had a problematic program contains many matches where the scrutinee itself contains nested matches (eg `match match match match match match t with ... with ... with ...`). in reduce_full_matches, it reduces the scrutinee and the branch, then if it can't apply case-of-constructor it backtracks, which ends up having to reduce the scrutinee and branch again separately. in my case with lots of nested matches, this seemed to be taking exponential time in the number of nested matches.