### PR TITLE
Nano-pass: remove empty records

### DIFF
--- a/test/StructWithUnitIsUnit.fst
+++ b/test/StructWithUnitIsUnit.fst
@@ -1,0 +1,5 @@
+module StructWithUnitIsUnit
+
+type t = { x: unit; }
+
+let main (x: t) = 0l

--- a/test/TwoUnitsAreOne.fst
+++ b/test/TwoUnitsAreOne.fst
@@ -1,0 +1,2 @@
+module TwoUnitsAreOne
+let main ((), ()) = 0l


### PR DESCRIPTION
As it turns out, the case where a struct is made of *only* ghost fields had previously never been exercised before. This is easily fixed with another nano-pass that performs a little bit of cleanup.