### PR TITLE
Extend Rust extraction support for ConstBuffer in subexpression positions

### DIFF
--- a/lib/AstToMiniRust.ml
+++ b/lib/AstToMiniRust.ml
@@ -873,9 +873,13 @@ and translate_expr_with_type (env: env) (e: Ast.expr) (t_ret: MiniRust.typ): env
       (* This is a fallback for the analysis above. Happens if, for instance, the pointer arithmetic
          appears in subexpression position (like, function call), in which case there's a chance
          this might still work! *)
+      let is_const_tbuf = match e1.typ with
+        | TBuf (_, b) -> b
+        | _ -> false
+      in
       let env, e1 = translate_expr env e1 in
       let env, e2 = translate_expr_with_type env e2 (Constant SizeT) in
-      env, Borrow (Mut, Index (e1, Range (Some e2, None, false)))
+      env, Borrow ((if is_const_tbuf then Shared else Mut), Index (e1, Range (Some e2, None, false)))
   | EBufDiff _ ->
       failwith "unexpected: EBufDiff"
   (* Silly pattern in Low*: for historical reasons, the blit operations takes a

--- a/test/Rust6.fst
+++ b/test/Rust6.fst
@@ -1,0 +1,45 @@
+module Rust6
+
+open FStar.HyperStack.ST
+
+module B = LowStar.Buffer
+module C = LowStar.ConstBuffer
+module HS = FStar.HyperStack
+
+inline_for_extraction noextract
+val sub_len:
+  b: C.const_buffer UInt32.t ->
+  Stack (C.const_buffer UInt32.t)
+  (requires fun h -> C.live h b /\ C.length b == 2)
+  (ensures  fun h0 r h1 -> h0 == h1 /\ C.live h1 r /\
+    C.length r == 2 /\
+    B.loc_includes (C.loc_buffer b) (C.loc_buffer r))
+
+let sub_len b =
+  C.sub b 0ul 2ul
+
+inline_for_extraction noextract
+val copy:
+  #a: Type
+  -> len:UInt32.t
+  -> o:B.buffer a
+  -> i:C.const_buffer a ->
+  Stack unit
+    (requires fun h0 -> B.live h0 o /\ C.live h0 i /\
+      B.length o == UInt32.v len /\ C.length i == UInt32.v len /\
+      B.disjoint (C.cast i) o)
+    (ensures  fun h0 _ h1 -> True)
+
+let copy #a len o i = LowStar.BufferOps.blit (C.cast i) 0ul o 0ul len
+
+let f (b: C.const_buffer UInt32.t) : ST unit
+  (requires fun h -> C.live h b /\ C.length b == 2)
+  (ensures fun _ _ _ -> True)
+  =
+  push_frame ();
+  let res = B.alloca 0ul 2ul in
+  copy 2ul res (sub_len b);
+  pop_frame()
+
+let main_ () : St Int32.t =
+  0l


### PR DESCRIPTION
This is a small tweak to the existing fallback for the case when a sub operation appears in subexpression position (e.g., as an argument to a function call), which happens in HACL* when using inline_for_extraction for sub operations.

The previous behavior was to always take a mutable borrow on the range created by the subbuffer. When using const buffers, this led to borrow-checking issues, where we tried to take a mutable borrow on a shared borrow. This PR slightly tweak this behavior to check (based on the argument type) whether the buffer argument is const. In this case, it is extracted as a shared borrow.

A small example (Rust6) showcases the problematic pattern, which is present in HACL*'s Ed25519/P256/K256 when using precomputed tables, where the function `f` was previously extracted to
```rust
pub fn f(b: &[u32]) -> ()
{
    let mut res: [u32; 2] = [0u32; 2usize];
    ((&mut res)[0usize..2usize]).copy_from_slice(&(&mut b[0usize..])[0usize..2usize])
}
```
This PR removes the inner mutable borrow of b.