### PR TITLE
Print split warnings with the function that they're in

### DIFF
--- a/include/krml/internal/target.h
+++ b/include/krml/internal/target.h
@@ -19,6 +19,14 @@
 #  define inline __inline__
 #endif
 
+#define DEBUG_ARRAY(w, x, l) do { \
+  printf("%s: [", #x); \
+  for (uint32_t i = 0; i < l; ++i) { \
+    printf("%"PRIx##w"%s", x[i], i == l - 1 ? "" : ", "); \
+  } \
+  printf("]\n"); \
+} while (0)
+
 /******************************************************************************/
 /* Macros that KaRaMeL will generate.                                         */
 /******************************************************************************/


### PR DESCRIPTION
Helpful for debugging hacl-rs compilation warnings