### PR TITLE
Protz rs unroll

### DIFF
--- a/lib/AstToMiniRust.ml
+++ b/lib/AstToMiniRust.ml
@@ -1037,8 +1037,6 @@ and translate_expr_with_type (env: env) (e: Ast.expr) (t_ret: MiniRust.typ): env
         translate_expr env body
 
       else begin
-        assert (n_loops <= 16);
-
         let unused = snd !(b.node.mark) = AtMost 3 in
         (* We do an ad-hoc thing since this didn't go through lowstar.ignore
            insertion. Rust uses the OCaml convention (which I recall I did suggest

--- a/src/Karamel.ml
+++ b/src/Karamel.ml
@@ -414,7 +414,7 @@ Supported options:|}
     exit 1
   end;
 
-  if !Options.unroll_loops > 16 then begin
+  if !Options.unroll_loops > 16 && not (Options.rust ()) then begin
     print_endline "Error: argument to -funroll-loops cannot be greater than 16";
     exit 1
   end;


### PR DESCRIPTION
Support for macro-based loop unrolling, relying on a proc macro (currently defined in HACL*).