### PR TITLE
CI for user manual: install pytz

### DIFF
--- a/.docker/hierarchic.Dockerfile
+++ b/.docker/hierarchic.Dockerfile
@@ -16,7 +16,7 @@ RUN sudo apt-get install -y nodejs rust-all
 # sudo pip3 because of https://bugs.launchpad.net/ubuntu/+source/bash/+bug/1588562
 # jinja2==3.0.0 because of https://github.com/mkdocs/mkdocs/issues/2799
 RUN sudo apt-get install --yes --no-install-recommends python3-pip python3-setuptools python3-distutils
-RUN sudo pip3 install --break-system-packages tzdata sphinx==1.7.2 jinja2==3.0.0 alabaster==0.7.13 sphinx_rtd_theme
+RUN sudo pip3 install --break-system-packages pytz tzdata sphinx==1.7.2 jinja2==3.0.0 alabaster==0.7.13 sphinx_rtd_theme
 
 # CI proper
 ARG CI_THREADS=24

--- a/.docker/standalone.Dockerfile
+++ b/.docker/standalone.Dockerfile
@@ -54,7 +54,7 @@ RUN sudo apt-get install -y --no-install-recommends nodejs
 # sudo pip3 because of https://bugs.launchpad.net/ubuntu/+source/bash/+bug/1588562
 # jinja2==3.0.0 because of https://github.com/mkdocs/mkdocs/issues/2799
 RUN sudo apt-get install --yes --no-install-recommends python3-pip python3-setuptools python3-distutils
-RUN sudo pip3 install --break-system-packages tzdata sphinx==1.7.2 jinja2==3.0.0 alabaster==0.7.13 sphinx_rtd_theme
+RUN sudo pip3 install --break-system-packages pytz tzdata sphinx==1.7.2 jinja2==3.0.0 alabaster==0.7.13 sphinx_rtd_theme
 
 # CI proper
 ARG CI_THREADS=24


### PR DESCRIPTION
following https://stackoverflow.com/a/73949524

This is confirmed to work with EverParse (see project-everest/everparse@4c532e5bca021c8c5c4293b3b7d7e2f57e22cbe4) : sphinx now correctly runs and updates EverParse's user manual.
