### PR TITLE
Substitutions are not type-preserving in C

### DIFF
--- a/lib/Simplify.ml
+++ b/lib/Simplify.ml
@@ -125,9 +125,12 @@ let use_mark_to_inline_temporaries = object (self)
   method! visit_ELet _ b e1 e2 =
     let e1 = self#visit_expr_w () e1 in
     let e2 = self#visit_expr_w () e2 in
+    let forces_decay = match b.typ, e1.typ with TBuf _, TArray _ -> true | _ -> false in
+    (* if forces_decay then *)
+    (*   KPrint.bprintf "NOT substituting away %s because it forces decay\n" b.node.name; *)
     let _, v = !(b.node.mark) in
     if (Helpers.is_uu b.node.name || b.node.name = "scrut" || Structs.should_rewrite b.typ = NoCopies) &&
-      v = AtMost 1 && (
+      v = AtMost 1 && not forces_decay && (
         is_readonly_c_expression e1 &&
         safe_readonly_use e2 ||
         safe_pure_use e2


### PR DESCRIPTION
So today I (re-?) discovered that substitutions are not type-preserving in C.

```
int x[1];
int *px = x;
int **ppx = &px;
```

substituting px away breaks typing:

```
int x[1];
int **ppx = &x;
```

does not work, because `&x` has type `(int*)[1]`. In other words, the intermediary declaration `px` forces array decay, which otherwise does not happen (because array decay is in function argument position, or assignment position). This makes sense: `&x` represents only a single level of indirection, not two.

The C compiler will flag this and reject the program. But of course we don't want to generate C code that doesn't compile, so rather than introduce a cast, we simply refuse to substitute away variables that force array decay.

This was only triggered by Eurydice, because due to a fortuitous scheduling of compilation passes, this was not exercised with the Low* frontend (& is only introduced very late as a cosmetic optimization when the frontend is Low*, and this happens after substitution of temporary variables).

This has no impact on HACL*.