### PR TITLE
Fix spinlock extraction due to stronger monomorphization

### DIFF
--- a/lib/Structs.ml
+++ b/lib/Structs.ml
@@ -419,6 +419,7 @@ let pass_by_ref files =
        single place in memory. *)
     (* | TQualified (["Test"], "t") *)
     | TApp ((["Steel"; "SpinLock"], "lock"), _)
+    | TQualified (["Steel"; "SpinLock"], "s_lock") 
     | TQualified (["Steel"; "SpinLock"], "lock__()") ->
         NoCopies
     | t ->


### PR DESCRIPTION
#431 introduced a stronger monomorphization, which in particular rewrites occurences of Steel_SpinLock_lock () into Steel_SpinLock_s_lock. This in turn leads to escaping the address-passing semantics of locks.

This PR fixes this by adding Steel_SpinLock_s_lock to the specific handling of locks.