### PR TITLE
Extend support for type abbreviations

### DIFF
--- a/lib/AstToMiniRust.ml
+++ b/lib/AstToMiniRust.ml
@@ -1269,6 +1269,7 @@ let translate_decl env (d: Ast.decl): MiniRust.decl option =
             method zero = false
             method plus = (||)
             method! visit_TBuf _ _ _ = true
+            method! visit_TQualified _ lid = Idents.LidSet.mem lid env.pointer_holding_structs
           end)#visit_typ () t in
           let lifetime, generic_params =
             if has_inner_pointer then


### PR DESCRIPTION
This PR extends support for type abbreviations to support aliases to other types that are lifetime parametric.

Consider the following output, which is similar to what happens in HACL-rs
```rust
pub type uint8_4p <`a> = &'a mut [u8];
pub type bufx4 = uint8_4p;
```

This will not compile, as both `bufx4` and `uint8_4p` should be indexed by a lifetime.
This PR will detect that `uint8_4p` is parametric in a lifetime, and therefore generate `pub type bufx4 <'a> = uint8_4p <'a>;`.
