### PR TITLE
always_inline seems to also require inline

### DIFF
--- a/include/krml/internal/target.h
+++ b/include/krml/internal/target.h
@@ -92,12 +92,12 @@
 
 #ifndef KRML_MUSTINLINE
 #  if defined(_MSC_VER)
-#    define KRML_MUSTINLINE __forceinline
+#    define KRML_MUSTINLINE inline __forceinline
 #  elif defined (__GNUC__)
-#    define KRML_MUSTINLINE __attribute__((always_inline))
+#    define KRML_MUSTINLINE inline __attribute__((always_inline))
 #  else
-#    define KRML_MUSTINLINE
-#    warning "The KRML_MUSTINLINE macro is not defined for this toolchain!"
+#    define KRML_MUSTINLINE inline
+#    warning "The KRML_MUSTINLINE macro defaults to plain inline for this toolchain!"
 #    warning "Please locate target.h and try to fill it out with a suitable definition for this compiler."
 #  endif
 #endif


### PR DESCRIPTION
When adding `__attribute((always_inline))` to a function, the compiler complains if it is not also marked with `inline`.
This PR changes the `KRML_MUSTINLINE` macro to always add `inline` as well.