### PR TITLE
(RFC) Add a test for mul_underspec

### DIFF
--- a/test/.hints/Underspec.fst.hints
+++ b/test/.hints/Underspec.fst.hints
@@ -1,0 +1,42 @@
+[
+  "B/É¸\u0002Ñ\u000fÁF\u0017¬—≤zê\u0006",
+  [
+    [
+      "Underspec.test1",
+      1,
+      2,
+      1,
+      [
+        "@MaxFuel_assumption", "@MaxIFuel_assumption",
+        "@fuel_correspondence_Prims.pow2.fuel_instrumented",
+        "@fuel_irrelevance_Prims.pow2.fuel_instrumented", "@query",
+        "b2t_def", "bool_inversion",
+        "equation_FStar.HyperStack.ST.equal_domains",
+        "equation_FStar.Monotonic.Heap.equal_dom",
+        "equation_FStar.Monotonic.HyperHeap.hmap",
+        "equation_FStar.Monotonic.HyperStack.is_tip",
+        "equation_FStar.Monotonic.HyperStack.is_wf_with_ctr_and_tip",
+        "equation_FStar.Monotonic.HyperStack.mem",
+        "equation_FStar.UInt.fits", "equation_FStar.UInt.max_int",
+        "equation_FStar.UInt.min_int", "equation_FStar.UInt.size",
+        "equation_Prims.nat",
+        "function_token_typing_FStar.Monotonic.Heap.heap", "int_typing",
+        "lemma_FStar.HyperStack.ST.lemma_same_refs_in_all_regions_intro",
+        "lemma_FStar.Map.lemma_ContainsDom",
+        "lemma_FStar.Set.lemma_equal_refl", "lemma_FStar.UInt.pow2_values",
+        "primitive_Prims.op_AmpAmp", "primitive_Prims.op_LessThanOrEqual",
+        "primitive_Prims.op_Subtraction",
+        "projection_inverse_BoxBool_proj_0",
+        "projection_inverse_BoxInt_proj_0",
+        "refinement_interpretation_Tm_refine_05e15190c946858f68c69156f585f95a",
+        "refinement_interpretation_Tm_refine_542f9d4f129664613f2483a6c88bc7c2",
+        "typing_FStar.Map.contains", "typing_FStar.Map.domain",
+        "typing_FStar.Monotonic.HyperHeap.rid",
+        "typing_FStar.Monotonic.HyperStack.get_hmap",
+        "typing_FStar.Monotonic.HyperStack.get_tip"
+      ],
+      0,
+      "99dab526a27ff2ff8a6b9b9f847572f3"
+    ]
+  ]
+]

--- a/test/Underspec.fst
+++ b/test/Underspec.fst
@@ -1,0 +1,20 @@
+module Underspec
+
+open FStar.HyperStack.ST
+module U32 = FStar.UInt32
+
+(* Checking that the *_underspec operators actually extract and run
+properly. *)
+
+(* Using this to prevent F*'s normalizers from reducing the tests.
+The operations should be there in the C code. *)
+irreducible
+let four = 4ul
+
+let test1 () : Stack bool (fun _ -> True) (fun _ _ _ -> True) =
+  FStar.UInt32.mul_underspec four 2ul = 8ul
+
+let main () =
+  if not <| test1 ()
+  then 1l
+  else 0l


### PR DESCRIPTION
Hi Jonathan, this PR adds a test for `mul_underspec` to test the patch in https://github.com/FStarLang/FStar/pull/3349.

I had to use this `irreducible` four definition to prevent the normalizer from simpliyfing the operation, so we actually try to extract it. Not sure if you have a better way?

I don't know if this is of much value as-is, maybe we can beef it up with other operations/widths too. For that I think `main` would look like
```fstar
if not (test1 ()) then 1l else
if not (test2 ()) then 1l else
if not (test3 ()) then 1l else
...
```
or something similar. 
