### PR TITLE
CI: automatically handle system dependency changes

### DIFF
--- a/.docker/build/install-deps.sh
+++ b/.docker/build/install-deps.sh
@@ -5,9 +5,6 @@ set -x
 
 build_home="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-# FIXME: the `opam depext` command should be unnecessary with opam 2.1
-opam depext conf-gmp z3.4.8.5-1 conf-m4
-
 # Identify the F* branch
 if [[ -z "$FSTAR_BRANCH" ]] ; then
     FSTAR_BRANCH=$(jq -c -r '.BranchName' "$build_home"/config.json)

--- a/.docker/hierarchic.Dockerfile
+++ b/.docker/hierarchic.Dockerfile
@@ -18,6 +18,10 @@ RUN sudo apt-get install -y nodejs rust-all
 RUN sudo apt-get install --yes --no-install-recommends python3-pip python3-setuptools python3-distutils
 RUN sudo pip3 install --break-system-packages pytz tzdata sphinx==1.7.2 jinja2==3.0.0 alabaster==0.7.13 sphinx_rtd_theme
 
+# unsafe-yes necessary to handle automatic system dependency changes with depext
+# See https://github.com/ocaml/opam/issues/4814
+ENV OPAMCONFIRMLEVEL=unsafe-yes
+
 # CI proper
 ARG CI_THREADS=24
 ARG CI_BRANCH=master

--- a/.docker/standalone.Dockerfile
+++ b/.docker/standalone.Dockerfile
@@ -35,7 +35,9 @@ SHELL ["/bin/bash", "--login", "-c"]
 ARG OCAML_VERSION=4.12.0
 RUN opam init --compiler=$OCAML_VERSION --disable-sandboxing 
 RUN opam env --set-switch | tee --append $HOME/.profile $HOME/.bashrc $HOME/.bash_profile
-ENV OPAMYES=1
+# unsafe-yes necessary to handle automatic system dependency changes with depext
+# See https://github.com/ocaml/opam/issues/4814
+ENV OPAMCONFIRMLEVEL=unsafe-yes
 
 ADD --chown=opam:opam ./ $HOME/karamel/
 WORKDIR $HOME/karamel


### PR DESCRIPTION
There was a system dependency change requiring to manually install `pkg-config`.

By using `OPAMCONFIRMLEVEL=unsafe-yes` instead of `OPAMYES=1` or the `--yes` option, following ocaml/opam#4814, this PR manages to handle such changes automatically.
