### PR TITLE
Rust backend: Rewrite according to the assign-op pattern

### DIFF
--- a/lib/MiniRust.ml
+++ b/lib/MiniRust.ml
@@ -88,6 +88,8 @@ and expr =
   | Panic of string
   | IfThenElse of expr * expr * expr option
   | Assign of expr * expr * typ
+  (* In-place update with operator, for instance ^= for xor. *)
+  | AssignOp of expr * op * expr * typ
   | As of expr * typ
   | For of binding * expr * expr
   | While of expr * expr

--- a/lib/OptimizeMiniRust.ml
+++ b/lib/OptimizeMiniRust.ml
@@ -260,6 +260,7 @@ let rec infer (env: env) (expected: typ) (known: known) (e: expr): known * expr 
       KPrint.bprintf "[infer-mut,assign] %a unsupported\n" PrintMiniRust.pexpr e;
       failwith "TODO: unknown assignment"
 
+  | AssignOp _ -> failwith "AssignOp nodes should only be introduced after mutability inference"
   | Var _
   | Array _
   | VecNew _

--- a/lib/PrintMiniRust.ml
+++ b/lib/PrintMiniRust.ml
@@ -384,6 +384,11 @@ and print_expr env (context: int) (e: expr): document =
       paren_if mine @@
       group (print_expr env left e1 ^^ space ^^ equals ^^
         (nest 4 (break1 ^^ print_expr env right e2)))
+  | AssignOp (e1, o, e2, _) ->
+      let mine, left, right = 18, 17, 18 in
+      paren_if mine @@
+      group (print_expr env left e1 ^^ space ^^ print_op o ^^ equals ^^
+        (nest 4 (break1 ^^ print_expr env right e2)))
   | As (e1, e2) ->
       let mine = 7 in
       paren_if mine @@


### PR DESCRIPTION
Another cosmetic change: when applicable, use the assign-op pattern on assignments where the rhs is a binary operator.
For instance, `x = x & y` becomes `x &= y`