### PR TITLE
Cosmetic changes to Rust backend

### DIFF
--- a/lib/Constant.ml
+++ b/lib/Constant.ml
@@ -41,6 +41,21 @@ type op =
   | Neg
   [@@deriving yojson,show]
 
+(* Determines is this is a comparison operator *)
+let is_comp_op = function
+  | Eq | Neq | Lt | Lte | Gt | Gte -> true
+  | _ -> false
+
+(* Negates the comparison operator *)
+let comp_neg = function
+  | Eq -> Neq
+  | Neq -> Eq
+  | Lt -> Gte
+  | Lte -> Gt
+  | Gt -> Lte
+  | Gte -> Lt
+  | _ -> failwith "not a comparison operator"
+
 let unsigned_of_signed = function
   | Int8 -> UInt8
   | Int16 -> UInt16

--- a/lib/OutputRust.ml
+++ b/lib/OutputRust.ml
@@ -8,7 +8,6 @@ let directives = String.trim {|
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]
 #![allow(unused_assignments)]
-#![allow(unused_mut)]
 #![allow(unreachable_patterns)]
 #![allow(const_item_mutation)]
 |}

--- a/lib/PrintMiniRust.ml
+++ b/lib/PrintMiniRust.ml
@@ -374,6 +374,8 @@ and print_expr env (context: int) (e: expr): document =
       group (string "if" ^/^ print_expr env max_int e1) ^/^
       print_block_expression env e2 ^^
       begin match e3 with
+      | Some (IfThenElse _ as e3) ->
+          break1 ^^ string "else" ^^ space ^^ print_block_or_if_expression env e3
       | Some e3 ->
           break1 ^^ string "else" ^/^ print_block_or_if_expression env e3
       | None ->


### PR DESCRIPTION
A few additional cosmetic changes to the Rust backend, following Clippy:
* Rewrite nonminimal boolean expressions (e.g., ! (x == y) becomes x != y)
* Print else if on the same line for nested if/then/else
* Use vec! for vector creation, with a small tweak for repeats of size 1
* Reintroduce the unused_mut warning, which was solved by mutability inference