### PR TITLE
Introduce -faggressive-inlining

### DIFF
--- a/lib/Options.ml
+++ b/lib/Options.ml
@@ -75,6 +75,7 @@ let microsoft = ref false
 let extern_c = ref false
 let short_names = ref true
 let cxx_compat = ref false
+let aggressive_inlining = ref false
 
 let extract_uints = ref false
 let builtin_uint128 = ref false

--- a/lib/Simplify.ml
+++ b/lib/Simplify.ml
@@ -117,7 +117,10 @@ let safe_pure_use e =
    uu____ in F*, or "scrut" if inserted by the pattern matches compilation
    phase), or that are of a type that cannot be copied (to hopefully skirt
    future failures). This phase assumes the mark field of each binder contains a
-   conservative approximation of the number of uses of that binder. *)
+   conservative approximation of the number of uses of that binder.
+
+   If the -faggressive-inlining option is provided, the inling is attempted
+   for every variable regardless of its name and type. *)
 let use_mark_to_inline_temporaries = object (self)
 
   inherit [_] map
@@ -126,7 +129,8 @@ let use_mark_to_inline_temporaries = object (self)
     let e1 = self#visit_expr_w () e1 in
     let e2 = self#visit_expr_w () e2 in
     let _, v = !(b.node.mark) in
-    if (b.node.attempt_inline ||
+    if (!Options.aggressive_inlining ||
+        b.node.attempt_inline ||
         Helpers.is_uu b.node.name ||
         b.node.name = "scrut" ||
         Structs.should_rewrite b.typ = NoCopies

--- a/src/Karamel.ml
+++ b/src/Karamel.ml
@@ -336,6 +336,8 @@ Supported options:|}
       for private (static) functions that are not exposed in headers; this ensures \
       robust collision-avoidance in case your private function names collide with \
       one of the included system headers";
+    "-faggressive-inlining", Arg.Set Options.aggressive_inlining, " attempt to inline \
+      every variable for more compact code-generation";
     "", Arg.Unit (fun _ -> ()), " ";
 
     (* For developers *)


### PR DESCRIPTION
Hi Jonathan, thanks for the tip yesterday about the inlining phase! It does make our code look much nicer.

In fact, I was thinking I would like this to be always done regardless of name and without requiring any attributes, so thought about adding this option, do you think it would be useful for others?

I could also add an attribute-based mechanism like you suggested if that's useful. If so, and if this option isn't desirable, maybe I can just have Pulse always add the attribute.