### PR TITLE
Prevent move-out on pointer holding structs

### DIFF
--- a/lib/AstToMiniRust.ml
+++ b/lib/AstToMiniRust.ml
@@ -828,7 +828,7 @@ and translate_expr_with_type (env: env) (e: Ast.expr) (t_ret: MiniRust.typ): env
       let t = translate_type env b.typ in
       let is_owned_struct =
         match b.typ with
-        | TQualified lid when Idents.LidSet.mem lid env.heap_structs -> true
+        | TQualified lid when Idents.LidSet.mem lid env.heap_structs || Idents.LidSet.mem lid env.pointer_holding_structs -> true
         | _ -> false
       in
       (* TODO how does this play out with the new "translate as non-mut by

--- a/lib/OptimizeMiniRust.ml
+++ b/lib/OptimizeMiniRust.ml
@@ -385,7 +385,7 @@ let rec infer (env: env) (expected: typ) (known: known) (e: expr): known * expr 
       known, e
 
   | Deref _ ->
-      failwith "TODO: Deref"
+      known, e
 
 (* We store here a list of builtins, with the types of their arguments.
    Type substitutions are currently not supported, functions with generic


### PR DESCRIPTION
As described in the title. There currently is some special-casing to avoid move-out when, e.g., accessing an array of non-Copy elements.
This PR extends what is considered as a non-Copy element to also consider pointer holding structs.