### PR TITLE
specify inline related attribute for Oracle Studio compiler

### DIFF
--- a/include/krml/internal/target.h
+++ b/include/krml/internal/target.h
@@ -82,6 +82,8 @@
 #    define KRML_NOINLINE __declspec(noinline)
 #  elif defined (__GNUC__)
 #    define KRML_NOINLINE __attribute__((noinline,unused))
+#  elif defined (__SUNPRO_C)
+#    define KRML_NOINLINE __attribute__((noinline))
 #  else
 #    define KRML_NOINLINE
 #    warning "The KRML_NOINLINE macro is not defined for this toolchain!"
@@ -94,6 +96,8 @@
 #  if defined(_MSC_VER)
 #    define KRML_MUSTINLINE inline __forceinline
 #  elif defined (__GNUC__)
+#    define KRML_MUSTINLINE inline __attribute__((always_inline))
+#  elif defined (__SUNPRO_C)
 #    define KRML_MUSTINLINE inline __attribute__((always_inline))
 #  else
 #    define KRML_MUSTINLINE inline


### PR DESCRIPTION
This change avoids warning/error when compiling with Oracle Studio by adding appropriate attributes for the inline enforcement. The `__SUNPRO_C` internal define  is documented in the Studio compiler man page for the `cc` command. The attribute values themselves are documented in https://docs.oracle.com/cd/E77782_01/pdf/E77788.pdf (section 2.10)

While the `__SUNPRO_C` define has a distinct value for every version, for this change I am assuming fairly modern version, i.e. 12.x, so the value is not checked. Let me know if that's okay.