### PR TITLE
lib: Makefile: FStar.IO.fst is now FStar.IO.fsti

### DIFF
--- a/krmllib/Makefile
+++ b/krmllib/Makefile
@@ -51,7 +51,7 @@ FSTAR = $(RUNLIM) $(FSTAR_EXE) $(FSTAR_OPTIONS) --cache_checked_modules --cache_
 # location of ulib.
 ROOTS = $(wildcard *.fst) $(wildcard *.fsti) $(wildcard ../runtime/*.fst) \
   FStar.UInt128.fst FStar.Date.fsti \
-    FStar.HyperStack.IO.fst FStar.IO.fst FStar.Int.Cast.Full.fst \
+    FStar.HyperStack.IO.fst FStar.IO.fsti FStar.Int.Cast.Full.fst \
     FStar.Bytes.fsti FStar.Dyn.fsti LowStar.Printf.fst LowStar.Endianness.fst
 
 .PHONY: clean clean-c


### PR DESCRIPTION
In support of ~https://github.com/FStarLang/FStar/pull/3549~ https://github.com/FStarLang/FStar/pull/3552, which makes FStar.IO an interface which is conceptually more correct.

I don't think this would have many users at the C level and would maybe just remove it from this list... but it is exposed, and has an implementation in krmllib/dist/generic/fstar_io.c.

This is motivated by the new F* build, I'm trying to get some smaller pieces in independent PRs.

---

Btw I read this comment:
https://github.com/FStarLang/karamel/blob/8c3612018c25889288da6857771be3ad03b75bcd/krmllib/Makefile#L50-L55
I'm not sure I understand it but F* can now be queried for exactly that by `fstar.exe --locate_lib`.