### PR TITLE
Makefile: improve confusing errors in inclusion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,16 @@
+# Including a Makefile from the visitors package, but making sure
+# to give decent errors.
+
 # make src/Ast.processed.ml
-include $(shell ocamlfind query visitors)/Makefile.preprocess
+_:=$(shell ocamlfind query)
+ifneq ($(.SHELLSTATUS),0)
+_: $(error "'ocamlfind query' failed, please install OCaml and put it in your PATH)
+endif
+visitors_root:=$(shell ocamlfind query visitors)
+ifneq ($(.SHELLSTATUS),0)
+_: $(error "'ocamlfind query visitors' failed, please 'opam install visitors')
+endif
+include $(visitors_root)/Makefile.preprocess
 
 .PHONY: all minimal clean test pre krmllib install
 


### PR DESCRIPTION
This line gives some bad errors whenever ocamlfind is not in the
PATH or the visitors package is not installed, and may carry on
with the Makefile regardless of that failure (attempting to include
/Makefile.preprocess along the way).

        $ make
        make: ocamlfind: No such file or directory
        Makefile:2: /Makefile.preprocess: No such file or directory
        make: *** No rule to make target '/Makefile.preprocess'.  Stop.

This patch makes the Makefile provide more helpful errors in both these
situations:

        $ make
        make: ocamlfind: No such file or directory
        Makefile:7: *** "'ocamlfind query' failed, please install OCaml and put it in your PATH.  Stop.

        $ make
        ocamlfind: Package `visitors' not found
        Makefile:11: *** "'ocamlfind query visitors' failed, please 'opam install visitors'.  Stop.
