### PR TITLE
Support false_elim

### DIFF
--- a/lib/InputAstToAst.ml
+++ b/lib/InputAstToAst.ml
@@ -155,6 +155,9 @@ and mk_expr = function
         mk_expr e;
         { node = EBufNull; typ = TBuf (mk_typ t, false); meta = [] }]))
 
+  | I.EApp (I.ETApp (I.EQualified ([ "FStar"; "Pervasives" ], "false_elim"), [ t ]), [ I.EUnit ]) ->
+      mk (EAbort (Some (mk_typ t), Some "provably unreachable code: did an unverified caller violate a precondition?"))
+
   | I.EApp (e, es) ->
       mk (EApp (mk_expr e, List.map mk_expr es))
   | I.ETApp (I.EOp ((K.Eq | K.Neq as op), _), [ t ]) ->


### PR DESCRIPTION
I'm quite surprised we never needed this before. I found it useful to document that a particular branch is statically unreachable, via the use of false_elim. Some other parts of HACL* do:

```
      let () = false_elim () in
      LowStar.Failure.failwith "statically unreachable"
```

which is slightly overkill, so I added support for false_elim, extracting as a regular call to KRML_ERROR, with a notice that the code was provably unreachable