### PR TITLE
change z3 version to 4.13.3

### DIFF
--- a/krmllib/Makefile
+++ b/krmllib/Makefile
@@ -84,7 +84,7 @@ obj:
 	mkdir $@
 
 %.checked: | obj
-	$(FSTAR) $(OTHERFLAGS) $< && \
+	$(FSTAR)  --z3version 4.13.3 $(OTHERFLAGS) $< && \
 	touch $@
 
 verify-all: $(ALL_CHECKED_FILES)


### PR DESCRIPTION
I am sure there may be a better place to put the `--z3version` but with this change, KaRaMeL works with the latest F* and Z3 4.13.3