### PR TITLE
Renormalize data types properly

### DIFF
--- a/lib/MonomorphizationState.ml
+++ b/lib/MonomorphizationState.ml
@@ -1,8 +1,23 @@
 open Ast
+open PrintAst.Ops
+
+(* Various bits of state for monomorphization, the two most important being
+   `state` (type monomorphization) and `generated_lids` (function
+   monomorphization). *)
+
+(* Monomorphization of data types. *)
 type node = lident * typ list * cg list
 type color = Gray | Black
+
+(* Each polymorphic type `lid` applied to types `ts` and const generics `ts`
+   appears in `state`, and maps to `monomorphized_lid`, the name of its
+   monomorphized instance. *)
 let state: (node, color * lident) Hashtbl.t = Hashtbl.create 41
 
+(* Because of polymorphic externals, one still encounters,
+   post-monomorphizations, application nodes in types (e.g. after instantiating
+   a polymorphic type scheme). The `resolve*` functions, below, normalize a type
+   to only contain monomorphic type names (and no more type applications) *)
 let resolve t: typ =
   match t with
   | TApp _ | TCgApp _ when Hashtbl.mem state (flatten_tapp t) ->
@@ -27,4 +42,17 @@ let resolve_deep = (object(self)
     resolve (TTuple ts)
 end)#visit_typ ()
 
-let generated_lids: (lident * expr list * typ list, lident) Hashtbl.t = Hashtbl.create 41
+(* Monomorphization of functions *)
+type reverse_mapping = (lident * expr list * typ list, lident) Hashtbl.t
+
+let generated_lids: reverse_mapping = Hashtbl.create 41
+
+let debug () =
+  Hashtbl.iter (fun (lid, ts, cgs) (_, monomorphized_lid) ->
+    KPrint.bprintf "%a <%a> <%a> ~~> %a\n" plid lid pcgs cgs ptyps ts plid
+    monomorphized_lid
+  ) state;
+  Hashtbl.iter (fun (lid, es, ts) monomorphized_lid ->
+    KPrint.bprintf "%a <%a> <%a> ~~> %a\n" plid lid pexprs es ptyps ts plid
+    monomorphized_lid
+  ) generated_lids


### PR DESCRIPTION
From the diff:

We need to renormalize entries in the data type monomorphization map for the Checker module. For
     instance, the map might contain `t (u v) -> t0` and `u v -> u0`, but at     this stage, we will have a type error when trying to compare  `t (u v)` and     `t u0`, since the latter does not appear in the map.

This fixes https://github.com/AeneasVerif/eurydice/issues/100