### PR TITLE
krml/Makefiles: unifying logic for detecting F*

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,22 +22,11 @@ endif
 
 all: minimal krmllib
 
-ifdef FSTAR_HOME
-  OCAMLPATH:=$(OCAMLPATH)$(OCAMLPATH_SEP)$(FSTAR_HOME)/lib
-else
-  FSTAR_EXE=$(shell which fstar.exe)
-  ifneq ($(FSTAR_EXE),)
-    FSTAR_HOME=$(dir $(FSTAR_EXE))/..
-    OCAMLPATH:=$(OCAMLPATH)$(OCAMLPATH_SEP)$(FSTAR_HOME)/lib
-  else
-    # If we are just trying to do a minimal build, we don't need F*.
-    ifneq ($(MAKECMDGOALS),minimal)
-      $(error "fstar.exe not found, please install FStar")
-    endif
-  endif
+# If we are just trying to do a minimal build, we don't need F*.
+ifneq ($(MAKECMDGOALS),minimal)
+include locate_fstar.mk
+export OCAMLPATH := $(OCAMLPATH)$(OCAMLPATH_SEP)$(shell $(FSTAR_EXE) --locate_ocaml)
 endif
-export FSTAR_HOME
-export OCAMLPATH
 
 minimal: lib/AutoConfig.ml lib/Version.ml
 	dune build
@@ -75,7 +64,7 @@ test: all
 # Auto-detection
 pre:
 	@ocamlfind query fstar.lib >/dev/null 2>&1 || \
-	  { echo "Didn't find fstar.lib via ocamlfind or in FSTAR_HOME (which is: $(FSTAR_HOME)); run $(MAKE) -C $(FSTAR_HOME)"; exit 1; }
+	  { echo "Didn't find fstar.lib via ocamlfind; is F* properly installed? (FSTAR_EXE = $(FSTAR_EXE))"; exit 1; }
 
 
 install: all

--- a/README.md
+++ b/README.md
@@ -48,9 +48,10 @@ make via homebrew, and invoke `gmake` instead of `make`.
 
 `$ opam install ppx_deriving_yojson zarith pprint "menhir>=20161115" sedlex process fix "wasm>=2.0.0" visitors ctypes-foreign ctypes uucp`
 
-Next, make sure you have an up-to-date F\*, and that you ran `make` in the
-`ulib/ml` directory of F\*. The `fstar.exe` executable should be on your PATH
-and `FSTAR_HOME` should point to the directory where F\* is installed.
+Next, make sure you have an up-to-date F\*, either as a binary package
+or that you have built it by running `make`. The `fstar.exe` executable
+should be on your PATH, or you may set the variable `FSTAR_EXE` to its
+location.
 
 To build just run `make` from this directory.
 

--- a/book/tutorial/Makefile
+++ b/book/tutorial/Makefile
@@ -51,19 +51,7 @@ FSTAR_EXTRACT = --extract 'OCaml:-* +Spec'
 # - --cache_checked_modules to rely on a pre-built ulib and krmllib
 # - --cache_dir, to avoid polluting our generated build artifacts outside o
 
-# Where is F* ?
-ifndef FSTAR_HOME
-  FSTAR_EXE=$(shell which fstar.exe)
-  ifneq ($(FSTAR_EXE),)
-    # Assuming that fstar.exe is in some ..../bin directory
-    FSTAR_HOME=$(dir $(FSTAR_EXE))/..
-  else
-    $(error "fstar.exe not found, please install FStar")
-  endif
-endif
-export FSTAR_HOME
-
-FSTAR_NO_FLAGS = $(FSTAR_HOME)/bin/fstar.exe $(FSTAR_HINTS) \
+FSTAR_NO_FLAGS = $(FSTAR_EXE) $(FSTAR_HINTS) \
   --odir obj --cache_checked_modules $(FSTAR_INCLUDES) --cmi \
   --already_cached 'Prims FStar LowStar C Spec.Loops TestLib WasmSupport' --warn_error '+241@247+285' \
   --cache_dir obj --hint_dir hints
@@ -234,9 +222,9 @@ dist/libbignum.a: dist/Makefile.basic
 # First complication... no comment.
 # NOTE: if F* was installed via opam, then this is redundant
 ifeq ($(OS),Windows_NT)
-  export OCAMLPATH := $(FSTAR_HOME)/lib;$(OCAMLPATH)
+  export OCAMLPATH := $(shell $(FSTAR_EXE) --locate_ocaml);$(OCAMLPATH)
 else
-  export OCAMLPATH := $(FSTAR_HOME)/lib:$(OCAMLPATH)
+  export OCAMLPATH := $(shell $(FSTAR_EXE) --locate_ocaml):$(OCAMLPATH)
 endif
 
 # Second complication: F* generates a list of ML files in the reverse linking

--- a/book/tutorial/Makefile.include
+++ b/book/tutorial/Makefile.include
@@ -4,21 +4,11 @@
 
 BIGNUM_HOME ?= .
 
-# Where is F* ?
-ifndef FSTAR_HOME
-  FSTAR_EXE=$(shell which fstar.exe)
-  ifneq ($(FSTAR_EXE),)
-    # Assuming that fstar.exe is in some ..../bin directory
-    FSTAR_HOME=$(dir $(FSTAR_EXE))/..
-  else
-    $(error "fstar.exe not found, please install FStar")
-  endif
-endif
-export FSTAR_HOME
-
 ifeq (,$(KRML_HOME))
   $(error KRML_HOME is not defined)
 endif
+
+include $(KRML_HOME)/locate_fstar.mk
 
 # I prefer to always check all fst files in the source directories; otherwise,
 # it's too easy to add a new file only to find out later that it's not being

--- a/krmllib/Makefile
+++ b/krmllib/Makefile
@@ -13,13 +13,7 @@ all: verify-all compile-all
 # Verification & extraction                                                    #
 ################################################################################
 
-ifdef FSTAR_HOME
-  # Assume there is a F* source tree
-  FSTAR_EXE=$(FSTAR_HOME)/bin/fstar.exe
-else
-  # Assume F* in the PATH
-  FSTAR_EXE=fstar.exe
-endif
+include ../locate_fstar.mk
 
 EXTRACT_DIR = .extract
 

--- a/locate_fstar.mk
+++ b/locate_fstar.mk
@@ -1,0 +1,27 @@
+# Find fstar.exe and set FSTAR_EXE to its absolute path.
+
+# If FSTAR_EXE is already externally set, we just use it. Note the use
+# of ?= everywhere below.
+
+# If FSTAR_HOME is set, we honor it and pick that F*.
+ifdef FSTAR_HOME
+FSTAR_EXE ?= $(abspath $(FSTAR_HOME)/bin/fstar.exe)
+endif
+
+# Otherwise we try to find it from the PATH.
+
+# Bash's 'type -P' is essentially 'which'. This relies on having bash
+# around, but does not require 'which'.
+FSTAR_EXE ?= $(shell bash -c 'type -P fstar.exe')
+
+# Force eval
+FSTAR_EXE := $(FSTAR_EXE)
+
+# Don't fail if we're cleaning
+ifneq ($(MAKECMDGOALS),clean)
+ifeq (,$(FSTAR_EXE))
+  $(error "Did not find fstar.exe in PATH and FSTAR_EXE/FSTAR_HOME unset, aborting.")
+endif
+endif
+
+export FSTAR_EXE

--- a/test/Makefile
+++ b/test/Makefile
@@ -5,18 +5,9 @@ ifeq (3.81,$(MAKE_VERSION))
     install make, then invoke gmake instead of make)
 endif
 
-ifdef FSTAR_HOME
-  # Assume there is a F* source tree
-  FSTAR_EXE=$(FSTAR_HOME)/bin/fstar.exe
-else
-  FSTAR_EXE=$(shell which fstar.exe)
-  ifeq ($(FSTAR_EXE),)
-    $(error "fstar.exe not found, please install F*")
-  endif
-  # Assume F* in the PATH, in some ..../bin directory
-  FSTAR_HOME=$(dir FSTAR_EXE)/..
-endif
+include ../locate_fstar.mk
 
+ifdef FSTAR_HOME
 CRYPTO = $(shell \
   if test -d $(FSTAR_HOME)/examples/low-level/crypto ; \
   then echo $(FSTAR_HOME)/examples/low-level/crypto ; \
@@ -24,6 +15,7 @@ CRYPTO = $(shell \
   then echo $(FSTAR_HOME)/share/fstar/examples/low-level/crypto ; \
   fi \
 )
+endif
 
 ifneq ($(CRYPTO),)
   CRYPTO_OPTS	= -I $(CRYPTO) -I $(CRYPTO)/real

--- a/test/sepcomp/a/Makefile
+++ b/test/sepcomp/a/Makefile
@@ -38,12 +38,7 @@ include Makefile.include
 # - --cache_checked_modules to rely on a pre-built ulib and krmllib
 # - --cache_dir, to avoid polluting our generated build artifacts outside o
 
-ifdef FSTAR_HOME
-  FSTAR_EXE=$(FSTAR_HOME)/bin/fstar.exe
-else
-  FSTAR_EXE=fstar.exe
-endif
-
+include $(KRML_HOME)/locate_fstar.mk
 FSTAR_NO_FLAGS = $(FSTAR_EXE) \
   --odir obj --cache_checked_modules $(FSTAR_INCLUDES) --cmi \
   --already_cached 'Prims FStar LowStar C Spec.Loops TestLib WasmSupport' --warn_error '+241@247+285' \

--- a/test/sepcomp/b/Makefile
+++ b/test/sepcomp/b/Makefile
@@ -39,12 +39,8 @@ include Makefile.include
 #   inline_for_extraction in the presence of interfaces
 # - --cache_checked_modules to rely on a pre-built ulib and krmllib
 # - --cache_dir, to avoid polluting our generated build artifacts outside o
-ifdef FSTAR_HOME
-  FSTAR_EXE=$(FSTAR_HOME)/bin/fstar.exe
-else
-  FSTAR_EXE=fstar.exe
-endif
 
+include $(KRML_HOME)/locate_fstar.mk
 FSTAR_NO_FLAGS = $(FSTAR_EXE) \
   --odir obj --cache_checked_modules $(FSTAR_INCLUDES) --cmi \
   --already_cached 'Prims FStar LowStar C Spec.Loops TestLib WasmSupport A' --warn_error '+241@247+285' \


### PR DESCRIPTION
Mostly preparing for using F* outside of a repo, i.e. without an FSTAR_HOME. The Makefiles and krml will now only locate fstar.exe, and call it to find its library and OCaml files. To find fstar.exe, the process is:
- First try to read the environment variable FSTAR_EXE.
- If unset, try FSTAR_HOME/bin/fstar.exe (for compatibility)
- If FSTAR_HOME is unset, check the PATH.

(I'm proposing other projects should use that logic too.. does it make sense? Steel is already doing via this same `locate_fstar.mk`)