### PR TITLE
Fix Rust cosmetic pass removing trailing units

### DIFF
--- a/lib/OptimizeMiniRust.ml
+++ b/lib/OptimizeMiniRust.ml
@@ -1116,7 +1116,7 @@ let remove_trailing_unit = object
     let e1 = super#visit_expr () e1 in
     let e2 = super#visit_expr () e2 in
     match e2 with
-    | Unit -> e1
+    | Unit when b.typ = Unit -> e1
     | _ -> Let (b, e1, e2)
 end
 


### PR DESCRIPTION
Slight refinement of the nanopass removing trailing units in the Rust backend.
Consider the following code
```rust
let x: u32 = 0;
()
```
With the previous version, the nanopass would have rewritten this code into `0`, leading to typechecking failures in Rust.

This PR tweaks the pass to only perform the rewriting when the previous expression has type unit.