### PR TITLE
Revise dependency analysis to be more precise

### DIFF
--- a/.github/workflows/linux-x64-hierarchic.yaml
+++ b/.github/workflows/linux-x64-hierarchic.yaml
@@ -16,7 +16,7 @@ jobs:
         run: |
           echo "CI_INITIAL_TIMESTAMP=$(date '+%s')" >> $GITHUB_ENV
       - name: Check out repo        
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Identify the base FStar branch and the notification channel
         run: |
           echo "FSTAR_BRANCH=$(jq -c -r '.BranchName' .docker/build/config.json)" >> $GITHUB_ENV
@@ -41,7 +41,7 @@ jobs:
           DZOMO_GITHUB_TOKEN: ${{ secrets.DZOMO_GITHUB_TOKEN }}
       - name: Archive build log
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: log
           path: log.txt


### PR DESCRIPTION
The dependency analysis was pretty coarse, and only represented dependencies from one "file" to either regular or internal headers. It turns out that the dependencies vary quite widely between that file's public header, internal header, or C implementation.

This was pointed out here: https://github.com/hacl-star/hacl-star/pull/1007#discussion_r1871934044

This revamps the analysis to now distinguish dependencies between { h file, internal/h file, c file } to { h file, internal/h file }.

The net result is a considerably reduced number of #includes in public headers.