### PR TITLE
Rework C compiler detection

### DIFF
--- a/lib/Error.ml
+++ b/lib/Error.ml
@@ -35,6 +35,7 @@ and raw_error =
   | IfDefOnGlobal of lident
   | NotLowStarCast of expr
   | LibraryPointerAmbiguity of lident * expr
+  | UnrecognizedCCompiler of string
 
 and location =
   string

--- a/lib/Options.ml
+++ b/lib/Options.ml
@@ -3,6 +3,28 @@
 
 type include_ = All | HeaderOnly of string | COnly of string
 
+type compiler_flavor =
+  | Generic
+  | GCC
+  | Clang
+  | Compcert
+  | MSVC
+
+let string_of_compiler_flavor = function
+  | Generic -> "generic"
+  | GCC -> "gcc"
+  | Clang -> "clang"
+  | Compcert -> "compcert"
+  | MSVC -> "msvc"
+
+let compiler_flavor_of_string = function
+  | "generic" -> Generic
+  | "gcc" -> GCC
+  | "clang" -> Clang
+  | "compcert" -> Compcert
+  | "msvc" -> MSVC
+  | s -> failwith ("unrecognized compiler flavor: " ^ s)
+
 let pinc b = function
   | All -> Buffer.add_string b "*"
   | HeaderOnly h -> Buffer.add_string b h; Buffer.add_string b ".h"
@@ -22,13 +44,14 @@ let fstar = ref "fstar.exe" (* F* command to use *)
 let add_include: (include_ * string) list ref = ref [ ]
 let add_include_tmh = ref false
 let add_early_include: (include_ * string) list ref = ref [ ]
-let warn_error = ref "+1@2@3+4..8@9+10@11+12..18@19+20..22+24..25@26@27"
+let warn_error = ref "+1@2@3+4..8@9+10@11+12..18@19+20..22+24..25@26..28"
 let tmpdir = ref "."
 let includes: string list ref = ref []
 let verbose = ref false
 let silent = ref false
 let exe_name = ref ""
-let cc = ref "gcc"
+let cc = ref ""
+let cc_flavor : compiler_flavor option ref = ref None
 let m32 = ref false
 let fsopts: string list ref = ref []
 let ccopts: string list ref = ref []
@@ -91,8 +114,8 @@ let c89_std = ref false
 let c89_scope = ref false
 
 (* A set of extra command-line arguments one gets for free depending on the
- * value of -cc *)
-let default_options () =
+ * detected C compiler. *)
+let default_options (k : compiler_flavor) =
   (* Note: the 14.04 versions of Ubuntu rely on the presence of _BSD_SOURCE to
    * enable the macros in endian.h; future versions use _DEFAULT_SOURCE which is
    * enabled by default, it seems, but there are talks of issuing a warning if
@@ -108,21 +131,20 @@ let default_options () =
   let gcc_options = Array.append gcc_like_options
     [| "-ccopt"; if !c89_std then "-std=c89" else "-std=c11" |]
   in
-  [
-    "gcc", gcc_options;
-    "clang", gcc_options;
-    "g++", gcc_like_options;
-    "compcert", [|
+  match k with
+  | GCC | Clang ->
+    if !cxx_compat
+    then gcc_like_options
+    else gcc_options
+  | Compcert -> [|
       "-warn-error"; "@6@8";
       "-fnostruct-passing"; "-fnoanonymous-unions";
       "-ccopts"; "-g,-D_BSD_SOURCE,-D_DEFAULT_SOURCE";
-    |];
-    "msvc", [|
+    |]
+  | MSVC -> [|
       "-warn-error"; "+6"; "-falloca"
-    |];
-    "", [| |]
-  ]
-
+    |]
+  | Generic -> [| |]
 
 (** Drop is now deprecated and there is not a single situation left that calls
     for it. If you must implement something with macros or static inline (i.e.,

--- a/lib/Warn.ml
+++ b/lib/Warn.ml
@@ -45,7 +45,7 @@ let failwith fmt =
 
 (* The main error printing function. *)
 
-let flags = Array.make 28 CError;;
+let flags = Array.make 29 CError;;
 
 (* When adding a new user-configurable error, there are *several* things to
  * update:
@@ -108,6 +108,8 @@ let errno_of_error = function
       26
   | LibraryPointerAmbiguity _ ->
       27
+  | UnrecognizedCCompiler _ ->
+      28
   | _ ->
       (** Things that cannot be silenced! *)
       0
@@ -216,6 +218,8 @@ let rec perr buf (loc, raw_error) =
       -library; and its definition is too ambiguous to tell whether it's an \
       array or a pointer. Disabling this warning is unsound. Definition \
       below:\n%a" plid lid pexpr e
+  | UnrecognizedCCompiler cc ->
+      p "Unrecognized C compiler: %s" cc
 
 let maybe_fatal_error error =
   flush stdout;


### PR DESCRIPTION
This patch makes karamel pick, by default, 'cc' from the path as the C compiler. This command can be overriden with the -cc option (taking the name of a program in the PATH, or a full path to an executable), or the CC environment variable (idem).

Since karamel passes specific options to different compilers, there is now logic to detect the flavor of compiler that karamel is talking to (e.g. by looking at `cc --version`).

*MISSING*: MSVC autodetection, and fixing the wrapper script. I don't have enough experience using it to know if we can tweak this script so as to only point it to an executable.

Also I think I should add a way to override the flavor in case autodetection fails.

(If you feel this change is more trouble than it's worth I'm ok dropping it.)

Fixes #529