### PR TITLE
feat(nix): add support for aarch64 linux & mac

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -6,7 +6,7 @@
   };
 
   outputs = { self, fstar, flake-utils, nixpkgs }:
-    flake-utils.lib.eachSystem [ "x86_64-linux" ] (system:
+    flake-utils.lib.eachDefaultSystem (system:
       let
         fstarPackages = fstar.packages.${system};
         pkgs = import nixpkgs { inherit system; };


### PR DESCRIPTION
This PR adds support for building karamel on apple machines using nix.