### PR TITLE
Support Assumed Declaration in MiniRust translation

### DIFF
--- a/lib/AstToMiniRust.ml
+++ b/lib/AstToMiniRust.ml
@@ -609,7 +609,7 @@ and translate_expr_with_type (env: env) (e: Ast.expr) (t_ret: MiniRust.typ): env
     (*   PrintMiniRust.ptyp t *)
     (*   PrintMiniRust.ptyp t_ret; *)
     begin match x, t, t_ret with
-    | _, (App (Name (["Box"], _), [Slice _]) | MiniRust.Vec _ | Array _), Ref (_, k, Slice _) ->
+    | _, (MiniRust.App (Name (["Box"], _), [Slice _]) | MiniRust.Vec _ | Array _), Ref (_, k, Slice _) ->
         Borrow (k, x)
     | Constant (w, x), Constant UInt32, Constant SizeT ->
         assert (w = Constant.UInt32);

--- a/lib/AstToMiniRust.ml
+++ b/lib/AstToMiniRust.ml
@@ -609,7 +609,7 @@ and translate_expr_with_type (env: env) (e: Ast.expr) (t_ret: MiniRust.typ): env
     (*   PrintMiniRust.ptyp t *)
     (*   PrintMiniRust.ptyp t_ret; *)
     begin match x, t, t_ret with
-    | _, (MiniRust.Vec _ | Array _), Ref (_, k, Slice _) ->
+    | _, (App (Name (["Box"], _), [Slice _]) | MiniRust.Vec _ | Array _), Ref (_, k, Slice _) ->
         Borrow (k, x)
     | Constant (w, x), Constant UInt32, Constant SizeT ->
         assert (w = Constant.UInt32);
@@ -622,8 +622,6 @@ and translate_expr_with_type (env: env) (e: Ast.expr) (t_ret: MiniRust.typ): env
         x
 
     (* More conversions due to box-ing types. *)
-    | _, App (Name (["Box"], _), [Slice _]), Ref (_, k, Slice _) ->
-        Borrow (k, x)
     | _, Ref (_, _, Slice _), App (Name (["Box"], _), [Slice _]) ->
         (* COPY *)
         MethodCall (Borrow (Shared, Deref x), ["into"], [])

--- a/lib/AstToMiniRust.ml
+++ b/lib/AstToMiniRust.ml
@@ -1400,8 +1400,13 @@ let translate_decl env (d: Ast.decl): MiniRust.decl option =
       let meta = translate_meta flags in
       Some (MiniRust.Constant { name; typ; body; meta })
 
-  | DExternal _ ->
-      None
+  | DExternal (_, _, _, _, lid, _, _) ->
+      let name, parameters, return_type =
+        match lookup_decl env lid with
+        | name, Function (_, parameters, return_type) -> name, parameters, return_type
+        | _ -> failwith " impossible"
+      in
+      Some (MiniRust.Assumed { name; parameters; return_type })
 
   | DType (lid, flags, _, _, decl) ->
       let name = lookup_type env lid in

--- a/lib/MiniRust.ml
+++ b/lib/MiniRust.ml
@@ -196,6 +196,14 @@ type decl =
     generic_params: generic_param list;
     meta: meta;
   }
+  (* We need to keep assumed/external functions to perform mutability inference
+     at the MiniRust level. However, these nodes will not be printed at code
+     generation *)
+  | Assumed of {
+    name: name;
+    parameters: typ list;
+    return_type: typ;
+  }
 
 and item =
   (* Not supporting tuples yet *)
@@ -383,7 +391,8 @@ let name_of_decl (d: decl) =
   | Enumeration { name; _ }
   | Struct { name; _ }
   | Function { name; _ }
-  | Constant { name; _ } ->
+  | Constant { name; _ }
+  | Assumed {name; _ } ->
       name
 
 let zero_usize: expr = Constant (Constant.SizeT, "0")

--- a/lib/OptimizeMiniRust.ml
+++ b/lib/OptimizeMiniRust.ml
@@ -101,7 +101,8 @@ let distill ts =
 (* Get the type of the arguments of `name`, based on the current state of
    `valuation` *)
 let lookup env valuation name =
-  (* KPrint.bprintf "lookup: %a\n" PrintMiniRust.pname name; *)
+  if not (NameMap.mem name env.signatures) then
+    KPrint.bprintf "ERROR looking up: %a\n" PrintMiniRust.pname name;
   let ts = NameMap.find name env.signatures in
   adjust ts (valuation name)
 

--- a/lib/OptimizeMiniRust.ml
+++ b/lib/OptimizeMiniRust.ml
@@ -1248,6 +1248,7 @@ let compute_derives files =
         match decl with
         | Function _ -> failwith "impossible"
         | Constant _ -> failwith "impossible"
+        | Assumed _ -> failwith "impossible"
         | Alias _  -> TraitSet.empty
         | Struct { fields; _ } ->
             let ts = List.map (fun (sf: struct_field) -> traits sf.typ) fields in

--- a/lib/OptimizeMiniRust.ml
+++ b/lib/OptimizeMiniRust.ml
@@ -1297,4 +1297,12 @@ let simplify_minirust files =
      have introduced unit statements *)
   let files = map_funs remove_trailing_unit#visit_expr files in
   let files = add_derives (compute_derives files) files in
+
+  (* Remove Assumed definitions, and filter empty files to avoid spurious code generation *)
+  let files = List.filter_map (fun (x, l) ->
+      (* Filter out assumed declarations *)
+      match List.filter (function | Assumed _ -> false | _ -> true) l with
+      | [] -> None (* No declaration left, we do not keep this file *)
+      | l -> Some (x, l)
+    ) files in
   files

--- a/lib/OptimizeMiniRust.ml
+++ b/lib/OptimizeMiniRust.ml
@@ -669,6 +669,8 @@ let infer_function (env: env) valuation (d: decl): decl =
          the traversal does not add or remove any bindings, but only increases the
          mutability, we can do a direct replacement instead of a more complex merge *)
       Function { f with body; parameters }
+  (* Assumed functions already have their mutability specified, we skip them *)
+  | Assumed _ -> d
   | _ ->
       assert false
 
@@ -1021,6 +1023,8 @@ let infer_mut_borrows files =
         List.filter_map (function
           | Function { parameters; name; _ } ->
               Some (name, List.map (fun (p: MiniRust.binding) -> p.typ) parameters)
+          | Assumed { name; parameters; _ } ->
+              Some (name, parameters)
           | _ ->
               None
         ) decls) files))
@@ -1044,6 +1048,7 @@ let infer_mut_borrows files =
     else
       match infer_function env valuation (NameMap.find name definitions) with
       | Function { parameters; _ } -> distill (List.map (fun (b: MiniRust.binding) -> b.typ) parameters)
+      | Assumed { parameters; _ } -> distill parameters
       | _ -> failwith "impossible"
   in
 

--- a/lib/OptimizeMiniRust.ml
+++ b/lib/OptimizeMiniRust.ml
@@ -1025,7 +1025,8 @@ let infer_mut_borrows files =
           | Function { parameters; name; _ } ->
               Some (name, List.map (fun (p: MiniRust.binding) -> p.typ) parameters)
           | Assumed { name; parameters; _ } ->
-              Some (name, parameters)
+	      if List.exists (fun (n, _) -> n = name) builtins then None
+              else Some (name, parameters)
           | _ ->
               None
         ) decls) files))

--- a/lib/PrintMiniRust.ml
+++ b/lib/PrintMiniRust.ml
@@ -605,6 +605,9 @@ let rec print_decl env (d: decl) =
       group @@
       group (print_meta meta ^^ string "type" ^/^ string target_name  ^^ print_generic_params generic_params ^/^ equals) ^/^
       group (print_typ env body ^^ semi)
+  (* Assumed declarations correspond to externals, which were propagated for mutability inference purposes.
+     We do not emit them *)
+  | Assumed _ -> empty
 
 and print_derives traits =
   group @@

--- a/lib/PrintMiniRust.ml
+++ b/lib/PrintMiniRust.ml
@@ -606,8 +606,8 @@ let rec print_decl env (d: decl) =
       group (print_meta meta ^^ string "type" ^/^ string target_name  ^^ print_generic_params generic_params ^/^ equals) ^/^
       group (print_typ env body ^^ semi)
   (* Assumed declarations correspond to externals, which were propagated for mutability inference purposes.
-     We do not emit them *)
-  | Assumed _ -> empty
+     They should have been filtered out during the MiniRust cleanup *)
+  | Assumed _ -> failwith "Assumed declaration remaining"
 
 and print_derives traits =
   group @@


### PR DESCRIPTION
PR in support of scylla, to integrate external (assumed) declarations when transpiling from C to Rust.

This PR translates `DExternal` declarations in Ast to a new `Assumed` node in MiniRust.
In particular, the translation preserves the mutability that was specified by the external declaration, and uses it for the mutability inference in `OptimizeMiniRust`. This behavior is overriden for external, "builtin" definitions.

Assumed definitions are then filtered and not extracted to Rust: Rust clients are expected to provide them directly.

The extraction of hacl-rs from Low* remains the same with this PR.