### PR TITLE
Allow const source buffers for EBufBlit

### DIFF
--- a/lib/Checker.ml
+++ b/lib/Checker.ml
@@ -402,10 +402,9 @@ and check' env t e =
       check_array_index env e3;
       c TUnit
 
-  | EBufBlit (b1, i1, b2, i2, len) ->
-      let t1, c1 = infer_buffer env b1 in
-      check_mut env "blit" c1;
-      check env (TBuf (t1, false)) b2;
+  | EBufBlit (b1 (* source *), i1, b2 (* destination *), i2, len) ->
+      let t1, _ = infer_buffer env b1 in  (* source can be const *)
+      check env (TBuf (t1, false)) b2;    (* destination must be non-const *)
       check_array_index env i1;
       check_array_index env i2;
       check_array_index env len;
@@ -713,10 +712,9 @@ and infer' env e =
       check_array_index env e3;
       TUnit
 
-  | EBufBlit (b1, i1, b2, i2, len) ->
-      let t1, c = infer_buffer env b1 in
-      check_mut env "blit" c;
-      check env (TBuf (t1, c)) b2;
+  | EBufBlit (b1 (* source *), i1, b2 (* destination *), i2, len) ->
+      let t1, _ = infer_buffer env b1 in  (* source can be const *)
+      check env (TBuf (t1, false)) b2;    (* destination must be non-const *)
       check_array_index env i1;
       check_array_index env i2;
       check_array_index env len;


### PR DESCRIPTION
In FStarLang/pulse#326, I am introducing Pulse mutable slices, and I am turning slices into immutable slices. For their C implementation, I am introducing `const` array pointers.
Then, I tried to refine the signature of corresponding memcpy operations so that the source pointer can be `const`. However, Karamel rejects me with:
>  blit requires a non-const pointer

This PR solves this issue by weakening the checks in `lib/Check.ml` to allow immutable source buffers. The destination buffer must still be mutable, though.

Everest green CI: https://github.com/project-everest/everest/actions/runs/13336176953