### PR TITLE
Improve the Rust extraction of Return nodes

### DIFF
--- a/lib/AstToMiniRust.ml
+++ b/lib/AstToMiniRust.ml
@@ -719,7 +719,9 @@ and translate_expr_with_type (env: env) (fn_t_ret: MiniRust.typ) (e: Ast.expr) (
       let e =
         begin match info.path with
         | None -> possibly_convert (Var v) typ
-        | Some (v_base, p) -> lookup_split env (v_base + v + 1) (Path p)
+        | Some (v_base, p) ->
+            let etyp = translate_type env e.typ in
+            possibly_convert (lookup_split env (v_base + v + 1) (Path p)) etyp
         end
       in
 

--- a/lib/OptimizeMiniRust.ml
+++ b/lib/OptimizeMiniRust.ml
@@ -176,10 +176,14 @@ let retrieve_pair_type (t: typ) =
 
 
 (*  known is the local state, which contains the V, R and P states (see above)
+    [expected] is the expected type of the expression (used to guide the translation).
+    [return_expected] is the expected type of the current funciton, which is needed
+    to handle guide the translation of expressions inside Return nodes, as a Return
+    node has expected type Unit.
 
     additionally, this function relies on `valuation` (for the least fixed point
     formulation of this analysis) and mutates `structs` globally *)
-let rec infer_expr (env: env) valuation (expected: typ) (known: known) (e: expr): known * expr =
+let rec infer_expr (env: env) valuation (return_expected: typ) (expected: typ) (known: known) (e: expr): known * expr =
   if Options.debug "rs-mut" then
     KPrint.bprintf "[infer_expr] %a @ %a\n" pexpr e ptyp expected;
   match e with
@@ -193,17 +197,17 @@ let rec infer_expr (env: env) valuation (expected: typ) (known: known) (e: expr)
         | Open { atom; _ } ->
             add_mut_var atom known, Borrow (Mut, e)
         | Index (e1, (Range _ as r))  ->
-            let known, e1 = infer_expr env valuation expected known e1 in
+            let known, e1 = infer_expr env valuation return_expected expected known e1 in
             known, Borrow (Mut, Index (e1, r))
 
         | Index (Open { atom; _ } as e1, e2)  ->
             let known = add_mut_var atom known in
-            let known, e2 = infer_expr env valuation Unit known e2 in
+            let known, e2 = infer_expr env valuation return_expected Unit known e2 in
             known, Borrow (Mut, Index (e1, e2))
 
         | Index (Borrow (_, (Open { atom; _ } as e1)), e2)  ->
             let known = add_mut_var atom known in
-            let known, e2 = infer_expr env valuation Unit known e2 in
+            let known, e2 = infer_expr env valuation return_expected Unit known e2 in
             known, Borrow (Mut, Index (Borrow (Mut, e1), e2))
 
         | Field (Open _, "0", None)
@@ -222,7 +226,7 @@ let rec infer_expr (env: env) valuation (expected: typ) (known: known) (e: expr)
             KPrint.bprintf "[infer_expr-mut, borrow] borrwing %a is not supported\n" pexpr e;
             failwith "TODO: borrowing something other than a variable"
       else
-        let known, e = infer_expr env valuation (assert_borrow expected) known e in
+        let known, e = infer_expr env valuation return_expected (assert_borrow expected) known e in
         known, Borrow (k, e)
 
   | Open { atom; _ } ->
@@ -237,7 +241,7 @@ let rec infer_expr (env: env) valuation (expected: typ) (known: known) (e: expr)
       (* KPrint.bprintf "[infer_expr-mut,let] %a\n" pexpr e; *)
       let a, e2 = open_ b e2 in
       (* KPrint.bprintf "[infer_expr-mut,let] opened %s[%s]\n" b.name (show_atom_t a); *)
-      let known, e2 = infer_expr env valuation expected known e2 in
+      let known, e2 = infer_expr env valuation return_expected expected known e2 in
       let mut_var = want_mut_var a known in
       let mut_borrow = want_mut_borrow a known in
       (* KPrint.bprintf "[infer_expr-mut,let-done-e2] %s[%s]: %a let mut ? %b &mut ? %b\n" b.name
@@ -245,7 +249,7 @@ let rec infer_expr (env: env) valuation (expected: typ) (known: known) (e: expr)
         ptyp b.typ mut_var mut_borrow;
       *)
       let t1 = if mut_borrow then make_mut_borrow b.typ else b.typ in
-      let known, e1 = infer_expr env valuation t1 known e1 in
+      let known, e1 = infer_expr env valuation return_expected t1 known e1 in
       known, Let ({ b with mut = mut_var; typ = t1 }, e1, close a (Var 0) (lift 1 e2))
 
   | Call (Name n, targs, es) ->
@@ -253,7 +257,7 @@ let rec infer_expr (env: env) valuation (expected: typ) (known: known) (e: expr)
         (* Since we do not have type-level substitutions in MiniRust, we special-case ignore here.
            Ideally, it would be added to builtins with `Bound 0` as a suitable type for the
            argument. *)
-        let known, e = infer_expr env valuation (KList.one targs) known (KList.one es) in
+        let known, e = infer_expr env valuation return_expected (KList.one targs) known (KList.one es) in
         known, Call (Name n, targs, [ e ])
       else if n = ["Box"; "new"] then
         (* FIXME: we no longer have the type handy so we can't recursively
@@ -262,15 +266,15 @@ let rec infer_expr (env: env) valuation (expected: typ) (known: known) (e: expr)
       else if n = [ "lib"; "memzero0"; "memzero" ] then
         (* Same as ignore above *)
         let e1, e2 = KList.two es in
-        let known, e1 = infer_expr env valuation (Ref (None, Mut, Slice (KList.one targs))) known e1 in
-        let known, e2 = infer_expr env valuation u32 known e2 in
+        let known, e1 = infer_expr env valuation return_expected (Ref (None, Mut, Slice (KList.one targs))) known e1 in
+        let known, e2 = infer_expr env valuation return_expected u32 known e2 in
         known, Call (Name n, targs, [ e1; e2 ])
       else
         (* TODO: substitute targs in ts -- for now, we assume we don't have a type-polymorphic
            function that gets instantiated with a reference type *)
         let ts = lookup env valuation n in
         let known, es = List.fold_left2 (fun (known, es) e t ->
-            let known, e = infer_expr env valuation t known e in
+            let known, e = infer_expr env valuation return_expected t known e in
             known, e :: es
           ) (known, []) es ts
         in
@@ -296,7 +300,7 @@ let rec infer_expr (env: env) valuation (expected: typ) (known: known) (e: expr)
   (* atom = e3 *)
   | Assign (Open { atom; _ } as e1, e3, t) ->
       (* KPrint.bprintf "[infer_expr-mut,assign] %a\n" pexpr e; *)
-      let known, e3 = infer_expr env valuation t known e3 in
+      let known, e3 = infer_expr env valuation return_expected t known e3 in
       add_mut_var atom known, Assign (e1, e3, t)
 
   (* atom[e2] = e2 *)
@@ -314,23 +318,23 @@ let rec infer_expr (env: env) valuation (expected: typ) (known: known) (e: expr)
   | Assign (Index (Field (Open {atom;_}, "1", None) as e1, e2), e3, t) ->
       (* KPrint.bprintf "[infer_expr-mut,assign] %a\n" pexpr e; *)
       let known = add_mut_borrow atom known in
-      let known, e2 = infer_expr env valuation usize known e2 in
-      let known, e3 = infer_expr env valuation t known e3 in
+      let known, e2 = infer_expr env valuation return_expected usize known e2 in
+      let known, e3 = infer_expr env valuation return_expected t known e3 in
       known, Assign (Index (e1, e2), e3, t)
 
   (* (x.f)[e2] = e3 *)
   | Assign (Index (Field (_, f, st (* optional type *)) as e1, e2), e3, t) ->
       add_mut_field (`Struct (assert_name st)) f;
-      let known, e2 = infer_expr env valuation usize known e2 in
-      let known, e3 = infer_expr env valuation t known e3 in
+      let known, e2 = infer_expr env valuation return_expected usize known e2 in
+      let known, e3 = infer_expr env valuation return_expected t known e3 in
       known, Assign (Index (e1, e2), e3, t)
 
   (* (&atom)[e2] = e3 *)
   | Assign (Index (Borrow (_, (Open { atom; _ } as e1)), e2), e3, t) ->
       (* KPrint.bprintf "[infer_expr-mut,assign] %a\n" pexpr e; *)
       let known = add_mut_var atom known in
-      let known, e2 = infer_expr env valuation usize known e2 in
-      let known, e3 = infer_expr env valuation t known e3 in
+      let known, e2 = infer_expr env valuation return_expected usize known e2 in
+      let known, e3 = infer_expr env valuation return_expected t known e3 in
       known, Assign (Index (Borrow (Mut, e1), e2), e3, t)
 
   | Assign (Field (_, "0", None), _, _)
@@ -340,30 +344,30 @@ let rec infer_expr (env: env) valuation (expected: typ) (known: known) (e: expr)
   (* (atom[e2]).f = e3 *)
   | Assign (Field (Index ((Open {atom; _} as e1), e2), f, st), e3, t) ->
       let known = add_mut_borrow atom known in
-      let known, e2 = infer_expr env valuation usize known e2 in
-      let known, e3 = infer_expr env valuation t known e3 in
+      let known, e2 = infer_expr env valuation return_expected usize known e2 in
+      let known, e3 = infer_expr env valuation return_expected t known e3 in
       known, Assign (Field (Index (e1, e2), f, st), e3, t)
 
   (* (&n)[e2] = e3 *)
   | Assign (Index (Borrow (_, Name n), e2), e3, t) ->
       (* This case should only occur for globals. For now, we simply mutably borrow it *)
-      let known, e2 = infer_expr env valuation usize known e2 in
-      let known, e3 = infer_expr env valuation t known e3 in
+      let known, e2 = infer_expr env valuation return_expected usize known e2 in
+      let known, e3 = infer_expr env valuation return_expected t known e3 in
       known, Assign (Index (Borrow (Mut, Name n), e2), e3, t)
 
   (* (&(&atom)[e2])[e3] = e4 *)
   | Assign (Index (Borrow (_, Index (Borrow (_, (Open {atom; _} as e1)), e2)), e3), e4, t) ->
       let known = add_mut_var atom known in
-      let known, e2 = infer_expr env valuation usize known e2 in
-      let known, e3 = infer_expr env valuation usize known e3 in
-      let known, e4 = infer_expr env valuation t known e4 in
+      let known, e2 = infer_expr env valuation return_expected usize known e2 in
+      let known, e3 = infer_expr env valuation return_expected usize known e3 in
+      let known, e4 = infer_expr env valuation return_expected t known e4 in
       known, Assign (Index (Borrow (Mut, Index (Borrow (Mut, e1), e2)), e3), e4, t)
 
   (* (&(atom.f))[e1] = e2 *)
   | Assign (Index (Borrow (_, Field (Open {atom; _} as e1, f, t)), e2), e3, t1) ->
       let known = add_mut_var atom known in
-      let known, e2 = infer_expr env valuation usize known e2 in
-      let known, e3 = infer_expr env valuation usize known e3 in
+      let known, e2 = infer_expr env valuation return_expected usize known e2 in
+      let known, e3 = infer_expr env valuation return_expected usize known e3 in
       known, Assign (Index (Borrow (Mut, Field (e1, f, t)), e2), e3, t1)
 
   | Assign _ ->
@@ -387,7 +391,7 @@ let rec infer_expr (env: env) valuation (expected: typ) (known: known) (e: expr)
       if expected <> Unit then
         let t_elt = match expected with Slice t | Array (t, _) -> t | _ -> failwith (KPrint.bsprintf "impossible: %a" ptyp expected) in
         let known, es = List.fold_left (fun (known, es) e ->
-          let known, e = infer_expr env valuation t_elt known e in
+          let known, e = infer_expr env valuation return_expected t_elt known e in
           known, e :: es
         ) (known, []) es in
         let es = List.rev es in
@@ -400,18 +404,18 @@ let rec infer_expr (env: env) valuation (expected: typ) (known: known) (e: expr)
          information from the copy_from_slice case, below *)
       if expected <> Unit then
         let t_elt = match expected with Slice t | Array (t, _) -> t | _ -> failwith (KPrint.bsprintf "impossible: %a" ptyp expected) in
-        let known, e = infer_expr env valuation t_elt known e in
+        let known, e = infer_expr env valuation return_expected t_elt known e in
         known, Array (Repeat (e, n))
       else
         known, e0
 
   | IfThenElse (e1, e2, e3) ->
-      let known, e1 = infer_expr env valuation bool known e1 in
-      let known, e2 = infer_expr env valuation expected known e2 in
+      let known, e1 = infer_expr env valuation return_expected bool known e1 in
+      let known, e2 = infer_expr env valuation return_expected expected known e2 in
       let known, e3 =
         match e3 with
         | Some e3 ->
-            let known, e3 = infer_expr env valuation expected known e3 in
+            let known, e3 = infer_expr env valuation return_expected expected known e3 in
             known, Some e3
         | None ->
             known, None
@@ -420,19 +424,19 @@ let rec infer_expr (env: env) valuation (expected: typ) (known: known) (e: expr)
 
   | As (e, t) ->
       (* Not really correct, but As is only used for integer casts *)
-      let known, e = infer_expr env valuation t known e in
+      let known, e = infer_expr env valuation return_expected t known e in
       known, As (e, t)
 
   | For (b, e1, e2) ->
-      let known, e2 = infer_expr env valuation Unit known e2 in
+      let known, e2 = infer_expr env valuation return_expected Unit known e2 in
       known, For (b, e1, e2)
 
   | While (e1, e2) ->
-      let known, e2 = infer_expr env valuation Unit known e2 in
+      let known, e2 = infer_expr env valuation return_expected Unit known e2 in
       known, While (e1, e2)
 
   | Return e ->
-      let known, e = infer_expr env valuation expected known e in
+      let known, e = infer_expr env valuation return_expected return_expected known e in
       known, Return e
 
   | MethodCall (e1, m, e2) ->
@@ -448,9 +452,9 @@ let rec infer_expr (env: env) valuation (expected: typ) (known: known) (e: expr)
           known, MethodCall (e1, m, e2)
       | ["split_at"] ->
           assert (List.length e2 = 1);
-          let known, e2 = infer_expr env valuation usize known (List.hd e2) in
+          let known, e2 = infer_expr env valuation return_expected usize known (List.hd e2) in
           let t1 = retrieve_pair_type expected in
-          let known, e1 = infer_expr env valuation t1 known e1 in
+          let known, e1 = infer_expr env valuation return_expected t1 known e1 in
           if is_mut_borrow expected then
             known, MethodCall (e1, ["split_at_mut"], [e2])
           else
@@ -461,15 +465,15 @@ let rec infer_expr (env: env) valuation (expected: typ) (known: known) (e: expr)
           | Index (dst, range) ->
               (* We do not have access to the types of e1 and e2. However, the concrete
                  type should not matter during mut infer_exprence, we thus use Unit as a default *)
-              let known, dst = infer_expr env valuation (Ref (None, Mut, Unit)) known dst in
-              let known, e2 = infer_expr env valuation (Ref (None, Shared, Unit)) known (List.hd e2) in
+              let known, dst = infer_expr env valuation return_expected (Ref (None, Mut, Unit)) known dst in
+              let known, e2 = infer_expr env valuation return_expected (Ref (None, Shared, Unit)) known (List.hd e2) in
               known, MethodCall (Index (dst, range), m, [e2])
           | _ ->
               (* The other form stems from Pulse.Lib.Slice which, here, puts an
                   actual slice on the left-hand side. *)
               let e2 = KList.one e2 in
-              let known, e1 = infer_expr env valuation (Ref (None, Mut, Slice Unit)) known e1 in
-              let known, e2 = infer_expr env valuation (Ref (None, Shared, Slice Unit)) known e2 in
+              let known, e1 = infer_expr env valuation return_expected (Ref (None, Mut, Slice Unit)) known e1 in
+              let known, e2 = infer_expr env valuation return_expected (Ref (None, Shared, Slice Unit)) known e2 in
               known, MethodCall (e1, m, [e2])
           end
       | [ "push" ] -> begin match e1 with
@@ -490,7 +494,7 @@ let rec infer_expr (env: env) valuation (expected: typ) (known: known) (e: expr)
       let fields_mut = Hashtbl.find structs name in
       let known, es = List.fold_left2 (fun (known, es) (fn, e) (f: struct_field) ->
         assert (fn = f.name);
-        let known, e = infer_expr env valuation f.typ known e in
+        let known, e = infer_expr env valuation return_expected f.typ known e in
         known, (fn, e) :: es
       ) (known, []) es fields_mut in
       let es = List.rev es in
@@ -498,10 +502,10 @@ let rec infer_expr (env: env) valuation (expected: typ) (known: known) (e: expr)
 
   | Match (e_scrut, t, arms) as _e_match ->
       (* We have the expected type of the scrutinee: valuation *)
-      let known, e = infer_expr env valuation t known e_scrut in
+      let known, e = infer_expr env valuation return_expected t known e_scrut in
       let known, arms = List.fold_left_map (fun known ((bs, _, _) as branch) ->
         let atoms, pat, e = open_branch branch in
-        let known, e = infer_expr env valuation expected known e in
+        let known, e = infer_expr env valuation return_expected expected known e in
         (* Given a pattern p of type t, and a known map:
           i.  if the pattern contains f = x *and* x is in R, then the field f of
               the struct type (provided by the context t) needs to be mutable --
@@ -610,8 +614,8 @@ let rec infer_expr (env: env) valuation (expected: typ) (known: known) (e: expr)
          earlier. This should therefore only occur when accessing a variable
          in an array *)
       let expected = Ref (None, Shared, expected) in
-      let known, e1 = infer_expr env valuation expected known e1 in
-      let known, e2 = infer_expr env valuation usize known e2 in
+      let known, e1 = infer_expr env valuation return_expected expected known e1 in
+      let known, e2 = infer_expr env valuation return_expected usize known e2 in
       known, Index (e1, e2)
 
   (* Special case for array slices. This occurs, e.g., when calling a function with
@@ -633,7 +637,7 @@ let rec infer_expr (env: env) valuation (expected: typ) (known: known) (e: expr)
   | Tuple es ->
       let t_elt = match expected with Tuple t -> t | _ -> failwith "impossible" in
       let known, es = List.fold_left2 (fun (known, es) e t ->
-        let known, e = infer_expr env valuation t known e in
+        let known, e = infer_expr env valuation return_expected t known e in
         known, e :: es
       ) (known, []) es t_elt in
       known, Tuple (List.rev es)
@@ -656,7 +660,7 @@ let infer_function (env: env) valuation (d: decl): decl =
       (* KPrint.bprintf "[infer-mut] done opening %s\n%a\n" (String.concat "." name)
         pexpr body; *)
       (* Start the analysis with the current state of struct mutability *)
-      let known, body = infer_expr env valuation return_type empty body in
+      let known, body = infer_expr env valuation return_type return_type empty body in
       let parameters, body =
         List.fold_left2 (fun (parameters, e) (binder: binding) atom ->
           let e = close atom (Var 0) (lift 1 e) in


### PR DESCRIPTION
As the translation from Ast to MiniRust is type-directed, translating a Return node needs the return type of the function being currently translated. This PR adds this type to the translation functions (and the mutability inference), and uses it for the EReturn/Return nodes.

It also fixes the translation of a split tree access with a missing `possibly_convert`.