### PR TITLE
Support for user-provided annotations about box types in Ast to Rust translation

### DIFF
--- a/lib/AstToMiniRust.ml
+++ b/lib/AstToMiniRust.ml
@@ -1567,8 +1567,11 @@ let compute_struct_info files boxed_types =
     method! visit_DFunction _ _ _ _ _ ret_t _ _ _ =
       match ret_t with
       | TQualified lid -> Idents.LidSet.singleton lid
-      | _ -> boxed_types
+      | _ -> Idents.LidSet.empty
   end)#visit_files () files in
+
+  (* Add types annotated as *must box* *)
+  let returned = Idents.LidSet.union boxed_types returned in
 
   (* Transitive closure: all the types that appear as part of a returned type. *)
   let returned =


### PR DESCRIPTION
The Ast to Rust translation relies on several heuristics to determine when pointer types should be translated to boxes.
This PR allows users to specify an additional list of types that *must* be translated to boxes.
The behavior for the F* to Rust extraction is left unchanged: this set is initialized to empty.