### PR TITLE
Add support for variable declaration in Rust

### DIFF
--- a/lib/AstToMiniRust.ml
+++ b/lib/AstToMiniRust.ml
@@ -760,8 +760,7 @@ and translate_expr_with_type (env: env) (fn_t_ret: MiniRust.typ) (e: Ast.expr) (
       env, Constant (Bool, string_of_bool b)
   | EString s ->
       env, ConstantString s
-  | EAny ->
-      failwith "unexpected: [expr] no casts in Low* -> Rust"
+  | EAny -> env, Empty
   | EAbort (_, s) ->
       env, Panic (Stdlib.Option.value ~default:"" s)
   | EIgnore _ ->

--- a/lib/MiniRust.ml
+++ b/lib/MiniRust.ml
@@ -113,6 +113,9 @@ and expr =
   | Operator of op
   | Deref of expr
 
+  (* Represents the absence of expression in a let-binding *)
+  | Empty
+
 and match_arm = binding list * pat * expr
 
 (* FIXME: could not reuse constructors like Struct, Var, and Open, using

--- a/lib/OptimizeMiniRust.ml
+++ b/lib/OptimizeMiniRust.ml
@@ -382,6 +382,7 @@ let rec infer_expr (env: env) valuation (return_expected: typ) (expected: typ) (
   | ConstantString _
   | Unit
   | Panic _
+  | Empty
   | Operator _ ->
       known, e
 

--- a/lib/PrintMiniRust.ml
+++ b/lib/PrintMiniRust.ml
@@ -274,6 +274,15 @@ and print_statements env (e: expr): document =
   | Let ({ typ = Unit; _ }, e1, e2) ->
       print_expr env max_int e1 ^^ semi ^^ hardline ^^
       print_statements (push env (GoneUnit)) e2
+  | Let ({ name; _ } as b, Empty, e2) ->
+      (* Special-case: this is a variable declaration without a definition *)
+      let name = allocate_name env name in
+      let b = { b with name } in
+      group (
+        string "let" ^/^ print_binding env b ^^ semi
+      ) ^^ hardline ^^
+      print_statements (push env (Bound b)) e2
+
   | Let ({ name; _ } as b, e1, e2) ->
       let name = allocate_name env name in
       let b = { b with name } in
@@ -501,6 +510,8 @@ and print_expr env (context: int) (e: expr): document =
 
   | Tuple es ->
       parens_with_nesting (separate_map comma (print_expr env max_int) es)
+
+  | Empty -> failwith "empty expression is not under a let binding"
 
 and print_data_type_name env = function
   | `Struct name -> print_name env name


### PR DESCRIPTION
Support variable declaration, without any definition associated.
We assume that such variables are identified as a let-binding, where the expression is an `EAny`, but with the type corresponding to the binding.