### PR TITLE
Add a new mode for generating C++17 code

### DIFF
--- a/lib/C11.ml
+++ b/lib/C11.ml
@@ -63,10 +63,14 @@ and expr =
   | CompoundLiteral of type_name * init list
   | MemberAccess of expr * ident
   | MemberAccessPointer of expr * ident
+  (* The three cases below are NOT in the C grammar *)
   | InlineComment of string * expr * string
   | Type of type_name
   | Stmt of stmt list
-    (** note: last three in the C grammar *)
+  (* Not in the C grammar either; encode a C++ initializer list that appears in expression position
+     so as to rely on an implicit constructor *)
+  | CxxInitializerList of init
+    
 
 (** this is a WILD approximation of the notion of "type name" in C _and_ a hack
  * because there's the invariant that the ident found at the bottom of the

--- a/lib/Options.ml
+++ b/lib/Options.ml
@@ -105,6 +105,7 @@ let microsoft = ref false
 let extern_c = ref false
 let short_names = ref true
 let cxx_compat = ref false
+let cxx17_compat = ref false
 
 let extract_uints = ref false
 let builtin_uint128 = ref false

--- a/lib/Output.ml
+++ b/lib/Output.ml
@@ -101,9 +101,12 @@ let prefix_suffix which original_name name =
   Driver.detect_fstar_if ();
   Driver.detect_karamel_if ();
   let if_cpp doc =
-    string "#if defined(__cplusplus)" ^^ hardline ^^
-    doc ^^ hardline ^^
-    string "#endif" ^^ hardline
+    if !Options.cxx17_compat then
+      empty
+    else
+      string "#if defined(__cplusplus)" ^^ hardline ^^
+      doc ^^ hardline ^^
+      string "#endif" ^^ hardline
   in
   let macro_name = String.map (function '/' -> '_' | c -> c) name in
   (* KPrint.bprintf "- add_early_includes: %s\n" original_name; *)

--- a/lib/PrintC.ml
+++ b/lib/PrintC.ml
@@ -308,8 +308,8 @@ and p_expr' curr = function
           (* C++17 initializer syntax T { ..., ... } *)
           p_type_name t
         else if !Options.cxx_compat then
-          (* CLITERAL works either in C++20 or C11 mode *)
-          string "CLITERAL" ^^ parens (p_type_name t)
+          (* KRML_CLITERAL works either in C++20 or C11 mode *)
+          string "KRML_CLITERAL" ^^ parens (p_type_name t)
         else
           parens (p_type_name t)) ^^
         braces_with_nesting (separate_map (comma ^^ break1) p_init init)

--- a/lib/PrintC.ml
+++ b/lib/PrintC.ml
@@ -290,14 +290,13 @@ and p_expr' curr = function
       (* We always parenthesize compound literals no matter what, because GCC
        * parses an application of a function to a compound literal as an n-ary
        * application. *)
-      if !Options.cxx_compat then
-       string "CLITERAL" ^^ parens (p_type_name t ^^ comma ^^ string "CFIELDS" ^^
-       parens (braces_with_nesting (separate_map (comma ^^ break1) p_init init)))
-      else
-        parens_with_nesting (
-          parens (p_type_name t) ^^
-          braces_with_nesting (separate_map (comma ^^ break1) p_init init)
-        )
+      parens_with_nesting (
+        (if !Options.cxx_compat then
+          string "CLITERAL" ^^ parens (p_type_name t)
+        else
+          parens (p_type_name t)) ^^
+        braces_with_nesting (separate_map (comma ^^ break1) p_init init)
+      )
   | MemberAccess (expr, member) ->
       p_expr' 1 expr ^^ dot ^^ string member
   | MemberAccessPointer (expr, member) ->
@@ -320,10 +319,7 @@ and p_expr e = p_expr' 15 e
 and p_init (i: init) =
   match i with
   | Designated (designator, i) ->
-      if !Options.cxx_compat then
-        string "CFIELD" ^^ parens (p_designator designator ^^ comma ^^ space ^^ p_init i)
-      else
-        p_designator designator ^^ space ^^ equals ^^ space ^^ p_init i
+      group (p_designator designator ^^ space ^^ equals ^^ space ^^ p_init i)
   | InitExpr e ->
       p_expr' 14 e
   | Initializer inits ->

--- a/src/Karamel.ml
+++ b/src/Karamel.ml
@@ -340,8 +340,10 @@ Supported options:|}
         aggressive always merges";
     "-fc89-scope", Arg.Set Options.c89_scope, "  use C89 scoping rules";
     "-fcast-allocations", Arg.Set Options.cast_allocations, "  cast allocations (for C89, or for C++)";
-    "-fc++-compat", Arg.Set Options.cxx_compat, "  various tweaks to make the \
-      generate code work in C++ mode: macro for C++20/C11 compound literals";
+    "-fc++-compat", Arg.Set Options.cxx_compat, "  make the \
+      generated code compile both as C11 and C++20";
+    "-fc++17-compat", Arg.Set Options.cxx17_compat, "  makes the code compile as C++17, but *NOT* as C \
+      code";
     "-fc89", Arg.Set arg_c89, "  generate C89-compatible code (meta-option, see \
       above) + also disable variadic-length KRML_HOST_EPRINTF + cast allocations";
     "-flinux-ints", Arg.Set Options.linux_ints, " use Linux kernel int types";


### PR DESCRIPTION
Code generated by krml by default works both in C11 and in C++20 -- the code can be compiled either by a C or a C++ compiler.

For downstream users who do not have C++20, this PR adds a new C++17 mode that generates code compatible with C++17 but *not* with C11. It may be that the code is compatible with C++11 but I have not checked that, so for now, the flag remains C++17.

