### PR TITLE
PrintC: nit, group operands

### DIFF
--- a/lib/PrintC.ml
+++ b/lib/PrintC.ml
@@ -241,7 +241,7 @@ and p_expr' curr = function
       let right = defeat_Wparentheses op e2 right in
       let e1 = p_expr' left e1 in
       let e2 = p_expr' right e2 in
-      paren_if curr mine (e1 ^/^ print_op op ^^ jump e2)
+      paren_if curr mine (group (e1 ^/^ print_op op) ^^ group (jump e2))
   | Index (e1, e2) ->
       let mine, left, right = 1, 1, 15 in
       let e1 = p_expr' left e1 in


### PR DESCRIPTION
Just a pretty-printing nit. I have some other readability improvements in a local branch, wondering if this stuff is useful or just adding noise.

----

This improves the printing so that the operands can break into multiples lines independendently of each other, and of the full expression. This is still not perfect, we could accumulate operands and `flow` them instead of this, but for a one liner it's a nice improvement.

Example, for:
```fstar
let foo (long_name : U64.t) : U64.t =
  let open FStar.UInt64 in
  (long_name -%^ long_name -%^ long_name -%^ long_name -%^ long_name -%^ long_name -%^ long_name)
  -%^ (long_name -%^ long_name -%^ long_name -%^ long_name -%^ long_name -%^ long_name -%^ long_name)
```

The code goes from
```c
uint64_t foo(uint64_t long_name)
{
  return
    long_name
    - long_name
    - long_name
    - long_name
    - long_name
    - long_name
    - long_name
    - (long_name - long_name - long_name - long_name - long_name - long_name - long_name);
}
```
To:
```c
uint64_t foo(uint64_t long_name)
{
  return
    long_name - long_name - long_name - long_name - long_name - long_name - long_name -
      (long_name - long_name - long_name - long_name - long_name - long_name - long_name);
}
```