### PR TITLE
nix: Don't use fstar's `ocamlPackages`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,7 @@
         fstarPackages = fstar.packages.${system};
         pkgs = import nixpkgs { inherit system; };
         karamel = pkgs.callPackage ./.nix/karamel.nix {
-          inherit (fstarPackages) fstar ocamlPackages z3;
+          inherit (fstarPackages) fstar z3;
           version = self.rev or "dirty";
         };
       in {


### PR DESCRIPTION
The nix situation around karamel is currently unfortunate: the `karamel` package itself uses `ocamlPackages_4_14`, but the downstream users I know about use 1. plain `ocamlPackages` (whose version depends on the chosen nixpkgs commit) 2. inherit `fstar/nixpkgs`.

By coincidence, the default ocaml toolchain in fstar's pinned nixpkgs is ocaml 4.14, so everything seems to work. However, the recent update of karamel to dune 3.13 requires a more recent nixpkgs. This ends up breaking a number of flakes.

One possible solution would be for downstream users of karamel to either pin ocaml 4.14 themselves or use `karamel.override { inherit (pkgs) ocamlPackages }`. However it seems karamel does not in fact use fstar as an ocaml dependency, so there's no need for it to use the same ocaml toolchain as fstar. Therefore the simplest solution seems to be to let karamel use the default `ocamlPackages`. That's what this PR does.

I have little familiarity with users of karamel and with the ocaml ecosystem in general, this may not be a correct solution for everyone.