### PR TITLE
Enhanced treatment of arrays in AstToMiniRust

### DIFF
--- a/lib/AstToMiniRust.ml
+++ b/lib/AstToMiniRust.ml
@@ -583,7 +583,16 @@ let rec translate_expr (env: env) (fn_t_ret: MiniRust.typ) (e: Ast.expr) : env *
   translate_expr_with_type env fn_t_ret e (translate_type env e.typ)
 
 and translate_expr_list (env: env) (fn_t_ret: MiniRust.typ) (es: Ast.expr list) : env * MiniRust.expr list =
-  List.fold_left (fun (env, acc) e -> let env, e = translate_expr env fn_t_ret e in env, acc @ [e]) (env, []) es
+  let env, acc =
+    List.fold_left (fun (env, acc) e -> let env, e = translate_expr env fn_t_ret e in env, e :: acc) (env, []) es
+  in
+  env, List.rev acc
+
+and translate_expr_list_with_types (env: env) (fn_t_ret: MiniRust.typ) (es: Ast.expr list) ts : env * MiniRust.expr list =
+  let env, acc =
+    List.fold_left2 (fun (env, acc) e t -> let env, e = translate_expr_with_type env fn_t_ret e t in env, e :: acc) (env, []) es ts
+  in
+  env, List.rev acc
 
 and translate_array (env: env) (fn_t_ret: MiniRust.typ) is_toplevel (init: Ast.expr): env * MiniRust.expr * MiniRust.typ =
   let to_array = function
@@ -639,9 +648,9 @@ and translate_expr_with_type (env: env) (fn_t_ret: MiniRust.typ) (e: Ast.expr) (
     (*   PrintMiniRust.pexpr x *)
     (*   PrintMiniRust.ptyp t *)
     (*   PrintMiniRust.ptyp t_ret; *)
-     (* Mutable borrows were only included for external definitions.
-        We erase them here; they will be handled during mutability inference, which will
-	be rechecked by the Rust compiler *)
+    (* Mutable borrows were only included for external definitions.
+       We erase them here; they will be handled during mutability inference, which will
+       be rechecked by the Rust compiler *)
     begin match x, erase_borrow_kind_info t, erase_borrow_kind_info t_ret with
     | _, (MiniRust.App (Name (["Box"], _), [Slice _]) | MiniRust.Vec _ | Array _), Ref (_, k, Slice _) ->
         Borrow (k, x)
@@ -846,8 +855,9 @@ and translate_expr_with_type (env: env) (fn_t_ret: MiniRust.typ) (e: Ast.expr) (
         | [ { typ = TUnit; node; _ } ] -> assert (node = EUnit); []
         | _ -> es
       in
+      let _t_ret, ts = Helpers.flatten_arrow e0.typ in
       let env, e0 = translate_expr env fn_t_ret e0 in
-      let env, es = translate_expr_list env fn_t_ret es in
+      let env, es = translate_expr_list_with_types env fn_t_ret es (List.map (translate_type env) ts) in
       env, possibly_convert (Call (e0, [], es)) (translate_type env e.typ)
 
   | ETApp (_, _, _, _) ->
@@ -1189,8 +1199,13 @@ and translate_expr_with_type (env: env) (fn_t_ret: MiniRust.typ) (e: Ast.expr) (
       let _, e_body = translate_expr (push env binding) fn_t_ret e_body in
       env0, For (binding, Range (Some e_start, Some e_end, false), e_body)
   | ECast (e, t) ->
-      let env, e = translate_expr env fn_t_ret e in
-      env, As (e, translate_type env t)
+      begin match t with
+      | TInt _ | TBool ->
+          let env, e = translate_expr env fn_t_ret e in
+          env, As (e, translate_type env t)
+      | _ ->
+          translate_expr_with_type env fn_t_ret e (translate_type env t)
+      end
   | EStandaloneComment _ ->
       failwith "TODO: EStandaloneComment"
   | EAddrOf _e1 ->

--- a/lib/AstToMiniRust.ml
+++ b/lib/AstToMiniRust.ml
@@ -1199,7 +1199,7 @@ and translate_expr_with_type (env: env) (fn_t_ret: MiniRust.typ) (e: Ast.expr) (
         combination with possibly_convert -- it compiles &x to &[x] where a copy
         of x is inserted into a slice, meaning further modifications affect a copy
         of x, not x itself *)
-      failwith "Unexpected: EAddrOf"
+      Warn.fatal_error "Unexpected: EAddrOf -- %a" PrintAst.Ops.pexpr _e1
       (* PREVIOUSLY: *)
       (* let env, e1_ = translate_expr env e1 in *)
       (* env, possibly_convert (Borrow (Mut, e1_)) (Ref (None, Mut, translate_type env e1.typ)) *)

--- a/lib/AstToMiniRust.ml
+++ b/lib/AstToMiniRust.ml
@@ -850,12 +850,11 @@ and translate_expr_with_type (env: env) (fn_t_ret: MiniRust.typ) (e: Ast.expr) (
       end
 
   | EApp (e0, es) ->
-      let es =
+      let es, ts =
         match es with
-        | [ { typ = TUnit; node; _ } ] -> assert (node = EUnit); []
-        | _ -> es
+        | [ { typ = TUnit; node; _ } ] -> assert (node = EUnit); [], []
+        | _ -> es, snd (Helpers.flatten_arrow e0.typ)
       in
-      let _t_ret, ts = Helpers.flatten_arrow e0.typ in
       let env, e0 = translate_expr env fn_t_ret e0 in
       let env, es = translate_expr_list_with_types env fn_t_ret es (List.map (translate_type env) ts) in
       env, possibly_convert (Call (e0, [], es)) (translate_type env e.typ)

--- a/lib/Helpers.ml
+++ b/lib/Helpers.ml
@@ -105,8 +105,11 @@ let mk_incr32 = mk_incr K.UInt32
 
 let mk_incr_usize = mk_incr K.SizeT
 
+let assert_tint_or_tbool t =
+  match t with TInt w -> w | TBool -> Bool | t -> Warn.fatal_error "Not an int/bool: %a" ptyp t
+
 let mk_neq e1 e2 =
-  with_type TBool (EApp (mk_op K.Neq K.UInt32, [ e1; e2 ]))
+  with_type TBool (EApp (mk_op K.Neq (assert_tint_or_tbool e1.typ), [ e1; e2 ]))
 
 let mk_not e1 =
   with_type TBool (EApp (mk_op K.Not K.Bool, [ e1 ]))


### PR DESCRIPTION
This removes un-necessary casts and improves array handling for Scylla.