### PR TITLE
Handle `let (x, _) = y;`

### DIFF
--- a/lib/OptimizeMiniRust.ml
+++ b/lib/OptimizeMiniRust.ml
@@ -1298,14 +1298,18 @@ end
 let cleanup_splits = object(self)
   inherit [_] map_expr as super
   method! visit_Match _ e_scrut t branches =
-    match t with
-    | Tuple [ _; _ ] ->
-        let bs, p, e = KList.one branches in
-        let b1, b2 = KList.two bs in
+    match t, branches with
+    | Tuple [ _; _ ], [ [ b1; b2 ], p, e] ->
         assert (match p with TupleP _ -> true | _ -> false);
         Let (b1, Some (Field (e_scrut, "0", None)),
         Let (b2, Some (Field (lift 1 e_scrut, "1", None)),
         self#visit_expr () e))
+    | Tuple [ _; _ ], [ [ b1 ], TupleP [ VarP _; Wildcard ], e] ->
+        Let (b1, Some (Field (e_scrut, "0", None)),
+        self#visit_expr () e)
+    | Tuple [ _; _ ], [ [ b2 ], TupleP [ Wildcard; VarP _ ], e] ->
+        Let (b2, Some (Field (e_scrut, "1", None)),
+        self#visit_expr () e)
     | _ ->
         super#visit_Match () e_scrut t branches
 end

--- a/lib/lib/KList.ml
+++ b/lib/lib/KList.ml
@@ -75,7 +75,7 @@ let one l =
 let two l =
   match l with
   | [ x; y ] -> (x, y)
-  | _ -> invalid_arg ("one: argument is of length " ^ string_of_int (List.length l))
+  | _ -> invalid_arg ("two: argument is of length " ^ string_of_int (List.length l))
 
 (* NOTE: provided by {!Stdlib.List} in OCaml 5.1. *)
 let is_empty = function

--- a/test/Makefile
+++ b/test/Makefile
@@ -314,6 +314,8 @@ WasmTrap.wasm-test: NEGATIVE = true
 	$(SED) -i 's/\(patterns..\)/\1\nmod lowstar { pub mod ignore { pub fn ignore<T>(_x: T) {}}}\n/' $@
 	echo 'fn main () { let r = main_ (); if r != 0 { println!("main_ returned: {}\\n", r); panic!() } }' >> $@
 
+$(OUTPUT_DIR)/rustpair.rs: KOPTS+=-fkeep-tuples
+
 %.rust-test: $(OUTPUT_DIR)/%.rs
 	rustc $< -o $*.exe && ./$*.exe
 

--- a/test/Rustpair.fst
+++ b/test/Rustpair.fst
@@ -1,0 +1,19 @@
+module Rustpair
+
+let foo (x: 'a & 'b) : Dv 'a =
+  match x with
+  | a, _ -> a
+
+let bar (x: 'a & 'b) : Dv 'b =
+  match x with
+  | _, b -> b
+
+let baz (x: 'a & 'b) : Dv bool =
+  match x with
+  | _, _ -> true
+
+let main_ () =
+  let _ = foo (4ul, true) in
+  let _ = bar (false, 4ul) in
+  let _ = baz (false, 4ul) in
+  0ul


### PR DESCRIPTION
We ran into this issue with the pair returned by `Slice.split`.