### PR TITLE
Support for local function calls in MiniRust AST -- this fixes #581

### DIFF
--- a/lib/OptimizeMiniRust.ml
+++ b/lib/OptimizeMiniRust.ml
@@ -315,9 +315,6 @@ let rec infer_expr (env: env) valuation (return_expected: typ) (expected: typ) (
         failwith "TODO: operator not supported"
     end
 
-  | Call _ ->
-      failwith "TODO: Call"
-
   (* atom = e3 *)
   | Assign (Open { atom; _ } as e1, e3, t) ->
       (* KPrint.bprintf "[infer_expr-mut,assign] %a\n" pexpr e; *)
@@ -413,6 +410,15 @@ let rec infer_expr (env: env) valuation (return_expected: typ) (expected: typ) (
       failwith "TODO: unknown assignment"
 
   | AssignOp _ -> failwith "AssignOp nodes should only be introduced after mutability infer_exprence"
+  | Call _
+    (* This catches the Call case where the head is neither an operator nor a toplevel function,
+       meaning we do not have type information available. (The MiniRust AST is not typed.)
+
+       What we do here is suboptimal: we do not infer anything regarding mutability -- we don't even
+       recursively visit the arguments (which would be useful, say, if one of the arguments was
+       itself a call to a toplevel function!), since we do not have type information.
+
+       At least this prevents hard errors for things that would otherwise compile. *)
   | Var _
   | VecNew _
   | Name _

--- a/lib/PrintMiniRust.ml
+++ b/lib/PrintMiniRust.ml
@@ -204,8 +204,9 @@ let rec print_typ env (t: typ): document =
   | Function (n, ts, t) ->
       let env = push_n_type env n in
       group @@
+      string "fn" ^/^
       group (parens (separate_map (comma ^^ break1) (print_typ env) ts)) ^/^
-      minus ^^ rangle ^^
+      minus ^^ rangle ^/^
       print_typ env t
   | Bound n ->
       begin try

--- a/test/RustFn.fst
+++ b/test/RustFn.fst
@@ -1,0 +1,15 @@
+module RustFn
+
+module U32 = FStar.UInt32
+
+let add_one (x: U32.t): U32.t =
+  x `FStar.UInt32.add_mod` 1ul
+
+let call (f: U32.t -> U32.t) (x: U32.t): U32.t = f x
+
+noeq type foo = { f: bool -> bool }
+let f b = not b
+let g () : foo = { f }
+let h (x: foo) = x.f true
+
+let main_ () = call add_one 0ul `FStar.UInt32.sub_mod` 1ul

--- a/test/Rustfn.fst
+++ b/test/Rustfn.fst
@@ -1,4 +1,4 @@
-module RustFn
+module Rustfn
 
 module U32 = FStar.UInt32
 


### PR DESCRIPTION
See the comments in the diff -- this unblocks you @gebner but if you have a function that takes a mutable reference then the mutability of the borrow will be inferred incorrectly.