### PR TITLE
Fix type abbreviations without lifetimes

### DIFF
--- a/lib/AstToMiniRust.ml
+++ b/lib/AstToMiniRust.ml
@@ -1582,6 +1582,8 @@ let compute_struct_info files boxed_types =
           Idents.LidMap.add lid fields acc
       | Ast.DType (lid, _, _, _, Variant branches) ->
           Idents.LidMap.add lid (List.concat_map (fun (_, fields) -> List.map (fun (c, f) -> Some c, f) fields) branches) acc
+      | Ast.DType (lid, _, _, _, Abbrev t) ->
+          Idents.LidMap.add lid [ None, (t, false) ] acc
       | _ ->
           acc
     ) acc decls

--- a/test/RustAbbrev.fst
+++ b/test/RustAbbrev.fst
@@ -1,0 +1,11 @@
+module RustAbbrev
+
+noeq type foo = {
+  b: LowStar.Buffer.buffer bool;
+}
+
+noeq type bar = {
+  c: foo;
+}
+
+let main_ () = 0ul

--- a/test/Rustabbrev.fst
+++ b/test/Rustabbrev.fst
@@ -1,4 +1,4 @@
-module RustAbbrev
+module Rustabbrev
 
 noeq type foo = {
   b: LowStar.Buffer.buffer bool;


### PR DESCRIPTION
This fixes #580