### PR TITLE
Infer mutability in function pointer fields.

### DIFF
--- a/lib/OptimizeMiniRust.ml
+++ b/lib/OptimizeMiniRust.ml
@@ -172,6 +172,22 @@ let add_mut_field (n: DataType.t) f =
     if sf.name = f then {sf with typ = fst (make_mut_borrow sf.typ) } else sf) fields in
   Hashtbl.replace structs n fields
 
+(* Update mutability of the arguments in a function type. *)
+let update_mut_args_fn_typ (t: typ) new_arg_tys : typ =
+  match t with
+  | Function (i, old_arg_tys, old_ret_ty) ->
+    Function (i, List.map2 (fun old_arg new_arg ->
+      if is_mut_borrow new_arg then fst (make_mut_borrow old_arg) else old_arg)
+      old_arg_tys new_arg_tys, old_ret_ty)
+  | _ -> t
+
+(* Update mutability of the arguments in a function pointer field. *)
+let update_mut_args_fn_field (n: DataType.t) fn new_arg_tys =
+  let fields = Hashtbl.find structs n in
+  let fields = List.map (fun (sf: MiniRust.struct_field) ->
+    if sf.name = fn then {sf with typ = update_mut_args_fn_typ sf.typ new_arg_tys } else sf) fields in
+  Hashtbl.replace structs n fields
+
 let retrieve_pair_type (t: typ) =
   match t with
   | Tuple [e1; e2] -> assert (e1 = e2); e1
@@ -313,6 +329,21 @@ let rec infer_expr (env: env) valuation (return_expected: typ) (expected: typ) (
       | _ ->
         KPrint.bprintf "[infer_expr-mut,call] %a not supported\n" pexpr e;
         failwith "TODO: operator not supported"
+    end
+
+  | Call (Field (_, f, st) as fld, [], args) ->
+    let fields = Hashtbl.find structs (`Struct (assert_name st)) in
+    let field = List.find (fun fld -> fld.name = f) fields in
+    begin match field.typ with
+    | Function (_, arg_tys, _) ->
+      let known, args = List.fold_left2 (fun (known, args) arg arg_ty ->
+          let known, arg = infer_expr env valuation return_expected arg_ty known arg in
+          known, arg :: args
+        ) (known, []) args arg_tys
+      in
+      known, Call (fld, [], args)
+    | _ ->
+      known, e
     end
 
   (* atom = e3 *)
@@ -539,6 +570,14 @@ let rec infer_expr (env: env) valuation (return_expected: typ) (expected: typ) (
       let known, es = List.fold_left2 (fun (known, es) (fn, e) (f: struct_field) ->
         assert (fn = f.name);
         let known, e = infer_expr env valuation return_expected f.typ known e in
+
+        (* If f is a function pointer field, update its argument types' mutabilities. *)
+        begin match f.typ, e with
+        | Function _, Name func ->
+          let fn_arg_tys = lookup env valuation func in
+          update_mut_args_fn_field name fn fn_arg_tys
+        | _ -> () end;
+
         known, (fn, e) :: es
       ) (known, []) es fields_mut in
       let es = List.rev es in

--- a/lib/OptimizeMiniRust.ml
+++ b/lib/OptimizeMiniRust.ml
@@ -341,6 +341,7 @@ let rec infer_expr (env: env) valuation (return_expected: typ) (expected: typ) (
           known, arg :: args
         ) (known, []) args arg_tys
       in
+      let args = List.rev args in
       known, Call (fld, [], args)
     | _ ->
       known, e

--- a/test/Rustfn3.fst
+++ b/test/Rustfn3.fst
@@ -1,0 +1,32 @@
+module Rustfn3
+module B = LowStar.Buffer
+open FStar.HyperStack.ST
+
+inline_for_extraction
+type t = r:B.lbuffer bool 1 -> Stack UInt32.t (requires fun h0 -> B.live h0 r) (ensures fun _ _ _ -> True)
+
+noeq type s = {
+  r: bool;
+  f: t;
+}
+
+let f : t = fun r ->
+  B.upd r 0ul true;
+  0ul
+
+// TODO: propagate mut from field type to function definition
+// let g : t = fun r ->
+//   0ul
+
+let h () =
+  push_frame ();
+  let ptr = B.alloca false 1ul in
+  let x = { r = false; f } in
+  let ret = x.f ptr in
+  // let y = { r = false; f = g } in
+  // let ret = UInt32.add ret (y.f ptr) in
+  pop_frame ();
+  ret
+
+let main_ () =
+  h ()

--- a/test/Rustfn3.fst
+++ b/test/Rustfn3.fst
@@ -3,14 +3,19 @@ module B = LowStar.Buffer
 open FStar.HyperStack.ST
 
 inline_for_extraction
-type t = r:B.lbuffer bool 1 -> Stack UInt32.t (requires fun h0 -> B.live h0 r) (ensures fun _ _ _ -> True)
+type t =
+  sz:SizeT.t ->
+  r:B.lbuffer bool (SizeT.v sz) ->
+  Stack UInt32.t
+    (requires fun h0 -> B.live h0 r /\ SizeT.v sz > 0)
+    (ensures fun _ _ _ -> True)
 
 noeq type s = {
   r: bool;
   f: t;
 }
 
-let f : t = fun r ->
+let f : t = fun _ r ->
   B.upd r 0ul true;
   0ul
 
@@ -22,7 +27,7 @@ let h () =
   push_frame ();
   let ptr = B.alloca false 1ul in
   let x = { r = false; f } in
-  let ret = x.f ptr in
+  let ret = x.f 1sz ptr in
   // let y = { r = false; f = g } in
   // let ret = UInt32.add ret (y.f ptr) in
   pop_frame ();


### PR DESCRIPTION
This implements a MVP for mutability inference in function pointer fields.  It's enough to extract EverCOSE to Rust.  But there's some limitations:
 - This is only for function pointers in structures; function pointers passed as arguments etc. are not supported yet.
 - Rust does not have variance for mutability, so if you want to assign a function `fn foo(a: &[u32]) -> bool` to a field with type `fn(&mut [u32]) -> bool`, then you need to mark the argument `a` of `foo` as mutable.  This is not implemented yet.

Fixes #590.  See also preceding PR #582.

cc @R1kM 