### PR TITLE
Add krml::unroll_for! to MiniRust printing environment

### DIFF
--- a/lib/PrintMiniRust.ml
+++ b/lib/PrintMiniRust.ml
@@ -666,7 +666,7 @@ let print_decl env d =
 
 let print_decls ns ds =
   let env = fresh ns in
-  let env, _ = register_global env ["krml"; "unroll_for!"] in
+  let env = { env with globals = NameMap.add ["krml"; "unroll_for!"] ["krml"; "unroll_for!"] env.globals } in
   let env, ds = List.fold_left (fun (env, ds) d ->
     let env, d = print_decl env d in
     env, d :: ds

--- a/lib/PrintMiniRust.ml
+++ b/lib/PrintMiniRust.ml
@@ -666,6 +666,7 @@ let print_decl env d =
 
 let print_decls ns ds =
   let env = fresh ns in
+  let env, _ = register_global env ["krml"; "unroll_for!"] in
   let env, ds = List.fold_left (fun (env, ds) d ->
     let env, d = print_decl env d in
     env, d :: ds

--- a/lib/PrintMiniRust.ml
+++ b/lib/PrintMiniRust.ml
@@ -666,6 +666,8 @@ let print_decl env d =
 
 let print_decls ns ds =
   let env = fresh ns in
+  (* We cannot call `register_globals` to register `unroll_for!`, as the ! character is
+     considered invalid and will be replaced by a median point. We thus do it manually *)
   let env = { env with globals = NameMap.add ["krml"; "unroll_for!"] ["krml"; "unroll_for!"] env.globals } in
   let env, ds = List.fold_left (fun (env, ds) d ->
     let env, d = print_decl env d in


### PR DESCRIPTION
Works around an interesting breakage of HACL-rs.

The Rust translation introduces calls to the `krml::unroll_for!` macro. However, the ! character is not considered as a valid identifier character, and will therefore be replaced by a median point whenever `lexical_conventions` is called on the `unroll_for!` name.
After #578, this function is called whenever a name is not part of the globals stored in the environment, which consisted of the top-level declarations, therefore leading to compilation errors.

To solve this, this PR initializes the Rust printing environment with a mapping for "unroll_for!". Note, it is important to add the mapping manually instead of through `register_globals`, as register_globals also cleans up names through `lexical_conventions`.

Note: if we are introducing other macros in the future, we will likely have the same issue.