### PR TITLE
Ensure covariance of function types

### DIFF
--- a/lib/AstToMiniRust.ml
+++ b/lib/AstToMiniRust.ml
@@ -462,6 +462,20 @@ let is_contained t =
   let t = KList.last t in
   List.exists (fun t' -> KString.starts_with t t') !Options.contained
 
+let has_pointer env =
+  (object
+    inherit [_] Ast.reduce as super
+    method zero = false
+    method plus = (||)
+    method! visit_TBuf _ _ _ = true
+    method! visit_TQualified _ lid = Idents.LidSet.mem lid env.pointer_holding_structs
+    method! visit_TApp env lid ts =
+      if lid = (["Pulse"; "Lib"; "Slice"], "slice") then
+        true
+      else
+        super#visit_TApp env lid ts
+  end)#visit_typ ()
+
 let rec translate_type_with_config (env: env) (config: config) (t: Ast.typ): MiniRust.typ =
   match t with
   | TInt w -> Constant w
@@ -492,6 +506,14 @@ let rec translate_type_with_config (env: env) (config: config) (t: Ast.typ): Min
   | TArrow _ ->
       let t, ts = Helpers.flatten_arrow t in
       let ts = match ts with [ TUnit ] -> [] | _ -> ts in
+      let needs_lifetime = has_pointer env t in
+      (* We need to find a fresh lifetime -- struct foo<'a> { a: for<'a> ... } is an error. *)
+      (* Function pointers refer to global functions so they can't refer to the enclosing lifetime anyhow. *)
+      let new_lifetime =
+        MiniRust.Label (match config.lifetime with
+          | Some (MiniRust.Label n) -> n ^ "1"
+          | None -> "a") in
+      let config = { config with lifetime = if needs_lifetime then Some new_lifetime else None } in
       let translate_parameter_type t =
         match translate_type_with_config env config t with
         | Ref (_, m, (Slice (Name (t, _ :: _)) as slice_t)) when is_contained t ->
@@ -502,7 +524,8 @@ let rec translate_type_with_config (env: env) (config: config) (t: Ast.typ): Min
         | t ->
             t
       in
-      Function (0, List.map translate_parameter_type ts, translate_type_with_config env config t)
+      Function (0, Option.to_list config.lifetime,
+        List.map translate_parameter_type ts, translate_type_with_config env config t)
   | TApp ((["Pulse"; "Lib"; "Slice"], "slice"), [ t ]) ->
       Ref (config.lifetime, Shared, Slice (translate_type_with_config env config t))
   | TApp _ -> failwith (KPrint.bsprintf "TODO: TApp %a" PrintAst.ptyp t)
@@ -651,6 +674,7 @@ and translate_expr_with_type (env: env) (fn_t_ret: MiniRust.typ) (e: Ast.expr) (
   let erase_lifetime_info = (object(self)
     inherit [_] MiniRust.DeBruijn.map
     method! visit_Ref env _ bk t = Ref (None, bk, self#visit_typ env t)
+    method! visit_Function env _ _ ts t = Function (0, [], List.map (self#visit_typ env) ts, self#visit_typ env t)
     method! visit_tname _ n _ = Name (n, [])
   end)#visit_typ ()
   in
@@ -673,7 +697,7 @@ and translate_expr_with_type (env: env) (fn_t_ret: MiniRust.typ) (e: Ast.expr) (
         Constant (SizeT, x)
     | _, Constant UInt32, Constant SizeT ->
         As (x, Constant SizeT)
-    | _, Function (_, ts, t), Function (_, ts', t') when ts = ts' && t = t' ->
+    | _, Function (_, _, ts, t), Function (_, _, ts', t') when ts = ts' && t = t' ->
         (* The type annotations coming from Ast do not feature polymorphic binders in types, but we
            do retain them in our Function type -- so we need to relax the comparison here *)
         x
@@ -1277,9 +1301,9 @@ and translate_pat env (p: Ast.pattern): MiniRust.pat =
 
 let make_poly (t: MiniRust.typ) n: MiniRust.typ =
   match t with
-  | Function (n', ts, t) ->
+  | Function (n', lt, ts, t) ->
       assert (n' = 0);
-      Function (n, ts, t)
+      Function (n, lt, ts, t)
   | _ ->
       (* Constants aren't supposed to be polymorphic *)
       assert (n = 0);
@@ -1291,20 +1315,6 @@ let is_handled_primitively = function
       KString.starts_with s "op_Star_Equals__"
   | _ ->
       false
-
-let has_pointer env =
-  (object
-    inherit [_] Ast.reduce as super
-    method zero = false
-    method plus = (||)
-    method! visit_TBuf _ _ _ = true
-    method! visit_TQualified _ lid = Idents.LidSet.mem lid env.pointer_holding_structs
-    method! visit_TApp env lid ts =
-      if lid = (["Pulse"; "Lib"; "Slice"], "slice") then
-        true
-      else
-        super#visit_TApp env lid ts
-  end)#visit_typ ()
 
 (* In Rust, like in C, all the declarations from the current module are in
  * scope immediately. This requires us to duplicate a little bit of work. *)
@@ -1322,6 +1332,7 @@ let bind_decl env (d: Ast.decl): env =
       in
       let needs_lifetime = has_pointer env t in
       let lifetime = if needs_lifetime then Some (MiniRust.Label "a") else None in
+      let lifetimes = Option.to_list lifetime in
       let config = { default_config with lifetime } in
 
       let parameters = List.map (fun (b: Ast.binder) ->
@@ -1346,7 +1357,7 @@ let bind_decl env (d: Ast.decl): env =
         in
         translate_type_with_config env { config with box } t
       in
-      push_decl env lid (name, Function (type_parameters, parameters, return_type))
+      push_decl env lid (name, Function (type_parameters, lifetimes, parameters, return_type))
 
   | DGlobal (_flags, lid, _, t, e) ->
       let typ = match e.node with
@@ -1465,7 +1476,7 @@ let translate_decl env { derives; attributes; _ } (d: Ast.decl): MiniRust.decl o
 
       let name, parameters, return_type =
         match lookup_decl env lid with
-        | name, Function (_, parameters, return_type) -> name, parameters, return_type
+        | name, Function (_, _, parameters, return_type) -> name, parameters, return_type
         | _ -> failwith "impossible"
       in
       let generic_params =
@@ -1502,7 +1513,7 @@ let translate_decl env { derives; attributes; _ } (d: Ast.decl): MiniRust.decl o
   | DExternal (_, _, _, _, lid, _, _) ->
       let name, parameters, return_type =
         match lookup_decl env lid with
-        | name, Function (_, parameters, return_type) -> name, parameters, return_type
+        | name, Function (_, _, parameters, return_type) -> name, parameters, return_type
         | _ -> failwith " impossible"
       in
       Some (MiniRust.Assumed { name; parameters; return_type })

--- a/lib/AstToMiniRust.ml
+++ b/lib/AstToMiniRust.ml
@@ -1662,16 +1662,18 @@ let compute_struct_info files boxed_types =
             inherit [_] Ast.reduce as super
             method zero = false
             method plus = (||)
+            method! visit_TArrow _ _ _ = self#zero
             method! visit_TQualified _ lid =
               valuation lid
             method! visit_TApp env lid ts =
               self#plus (valuation lid) (super#visit_TApp env lid ts)
           end)#visit_fields_t_opt () fields
         in
-        let directly_contains_pointers = (object(_)
+        let directly_contains_pointers = (object(self)
             inherit [_] Ast.reduce as super
             method zero = false
             method plus = (||)
+            method! visit_TArrow _ _ _ = self#zero
             method! visit_TBuf _ _ _ = true
             method! visit_TApp env lid ts =
               match lid, ts with

--- a/lib/MiniRust.ml
+++ b/lib/MiniRust.ml
@@ -34,7 +34,7 @@ type typ =
   | Array of typ * int [@name "tarray"]
   | Slice of typ (* always appears underneath Ref *)
   | Unit [@name "tunit"]
-  | Function of int * typ list * typ
+  | Function of int * lifetime list * typ list * typ
   | Name of name * generic_param list [@name "tname"]
   | Tuple of typ list [@name "ttuple"]
   | App of typ * typ list

--- a/lib/OptimizeMiniRust.ml
+++ b/lib/OptimizeMiniRust.ml
@@ -175,8 +175,8 @@ let add_mut_field (n: DataType.t) f =
 (* Update mutability of the arguments in a function type. *)
 let update_mut_args_fn_typ (t: typ) new_arg_tys : typ =
   match t with
-  | Function (i, old_arg_tys, old_ret_ty) ->
-    Function (i, List.map2 (fun old_arg new_arg ->
+  | Function (i, lt, old_arg_tys, old_ret_ty) ->
+    Function (i, lt, List.map2 (fun old_arg new_arg ->
       if is_mut_borrow new_arg then fst (make_mut_borrow old_arg) else old_arg)
       old_arg_tys new_arg_tys, old_ret_ty)
   | _ -> t
@@ -335,7 +335,7 @@ let rec infer_expr (env: env) valuation (return_expected: typ) (expected: typ) (
     let fields = Hashtbl.find structs (`Struct (assert_name st)) in
     let field = List.find (fun fld -> fld.name = f) fields in
     begin match field.typ with
-    | Function (_, arg_tys, _) ->
+    | Function (_, _, arg_tys, _) ->
       let known, args = List.fold_left2 (fun (known, args) arg arg_ty ->
           let known, arg = infer_expr env valuation return_expected arg_ty known arg in
           known, arg :: args
@@ -1409,7 +1409,7 @@ let compute_derives files =
             self#plus (self#visit_typ () t) (if m = Mut then TraitSet.singleton PartialEq else everything)
           method! visit_Vec _ t =
             self#plus (self#visit_typ () t) (TraitSet.of_list [ PartialEq; Clone ])
-          method! visit_Function _ _ _ _ =
+          method! visit_Function _ _ _ _ _ =
             everything
           method! visit_App _ t ts =
             match t with

--- a/lib/PrintMiniRust.ml
+++ b/lib/PrintMiniRust.ml
@@ -201,13 +201,16 @@ let rec print_typ env (t: typ): document =
   | Array (t, n) -> group (brackets (print_typ env t ^^ semi ^/^ int n))
   | Slice t -> group (brackets (print_typ env t))
   | Unit -> parens empty
-  | Function (n, ts, t) ->
-      let env = push_n_type env n in
+  | Function (n, [], ts, t) ->
+    let env = push_n_type env n in
       group @@
       string "fn" ^/^
       group (parens (separate_map (comma ^^ break1) (print_typ env) ts)) ^/^
       minus ^^ rangle ^/^
       print_typ env t
+  | Function (n, lt, ts, t) ->
+    group (string "for" ^^ langle ^^ separate_map (comma ^^ break1) print_lifetime lt ^^ rangle) ^/^
+      print_typ env (Function (n, [], ts, t))
   | Bound n ->
       begin try
         string (lookup_type env n)

--- a/test/Rustfn4.fst
+++ b/test/Rustfn4.fst
@@ -1,0 +1,41 @@
+module Rustfn4
+module B = LowStar.Buffer
+open FStar.HyperStack.ST
+
+inline_for_extraction
+type t =
+  r:B.lbuffer bool 1 ->
+  Stack (B.lbuffer bool 1)
+    (requires fun h0 -> B.live h0 r)
+    (ensures fun _ _ _ -> True)
+
+noeq type s = {
+  r: B.lbuffer bool 1;
+  f: t;
+}
+
+let f : t = fun r ->
+  B.upd r 0ul true;
+  r
+
+let g (x: s) :
+    Stack unit
+      (requires fun h0 -> B.live h0 x.r)
+      (ensures fun _ _ _ -> True) =
+  let _ = x.f x.r in ()
+
+let h (x: s) =
+  push_frame ();
+  let ptr = B.alloca false 1ul in
+  g { x with r = ptr };
+  pop_frame ()
+
+let i () =
+  push_frame ();
+  let ptr = B.alloca false 1ul in
+  let x = { r = ptr; f } in
+  h x;
+  pop_frame ()
+
+let main_ () =
+  i (); 0ul


### PR DESCRIPTION
Right now we extract function pointers to Rust as follows:
```rust
pub struct s<'a> {
    pub r: &'a mut [bool],
    pub f: fn(&'a mut [bool]) -> &'a [bool],
}
```

This is very obviously a massive issue, since it forces the type `s` to be invariant in the lifetime `'a`.  This PR changes the extraction to quantify over the lifetime in the function type instead:
```rust
pub struct s<'a> {
    pub r: &'a mut [bool],
    pub f: for<'a1> fn(&'a1 mut [bool]) -> &'a1 [bool],
}
```

Now the function pointer no longer has any free lifetime variables, and `s` can be the covariant type it wants to be.