### PR TITLE
Shorter test output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@ karamel-nofstar.opam
 lib/AutoConfig.ml
 *.orig
 .exrc
+*.cmd
+*.err
+*.output
+*.time

--- a/Makefile.common
+++ b/Makefile.common
@@ -1,0 +1,43 @@
+SHELL:=$(shell which bash)
+
+ifeq ($(shell uname -s),Darwin)
+  ifeq (,$(shell which gtime))
+    $(error gtime not found; try brew install gnu-time)
+  endif
+  TIME := gtime -q -f '%E'
+else ifeq ($(shell uname -s),FreeBSD)
+  TIME := /usr/bin/time
+else
+  ifeq ($(shell which time),)
+    $(error 'time' not found, try apt-get install time)
+  endif
+  TIME := $(shell which time) -q -f '%E'
+endif
+
+# A helper to generate pretty logs, callable as:
+#   $(call run-with-log,CMD,TXT,STEM)
+#
+# Arguments:
+#  CMD: command to execute (may contain double quotes, but not escaped)
+#  TXT: readable text to print out once the command terminates
+#  STEM: path stem for the logs, stdout will be in STEM.output, stderr in STEM.err, CMD in STEM.cmd
+ifeq (,$(NOSHORTLOG))
+run-with-log = \
+  @echo "$(subst ",\",$1)" > $3.cmd; \
+  $(TIME) -o $3.time sh -c "$(subst ",\",$1)" > $3.output 2> >( tee $3.err 1>&2 ); \
+  ret=$$?; \
+  time=$$(cat $3.time); \
+  if [ $$ret -eq 0 ]; then \
+    echo "$2, $$time"; \
+  else \
+    echo "<><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>"; \
+    echo -e "\033[31mFatal error while running\033[0m: $1"; \
+    echo -e "\033[31mFailed after\033[0m: $$time"; \
+    echo -e "\033[36mFull log is in $3.{output,err}, see excerpt below\033[0m:"; \
+    tail -n 20 $3.err; \
+    echo "<><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>"; \
+    false; \
+  fi
+else
+run-with-log = $(WRAP) $(RUNLIM) $1
+endif

--- a/lib/Structs.ml
+++ b/lib/Structs.ml
@@ -264,6 +264,7 @@ let pass_by_ref (externals: Idents.LidSet.t) (should_rewrite: _ -> policy) = obj
           (* Fast-path: the body is a single application node, meaning that the we can optimize and
              directly pass our own destination parameter to the callee, rather than generating a
              temporary that ends up memcpy'd into our own destination parameter. *)
+          let es = List.map (self#visit_expr_w to_be_starred) es in
           self#rewrite_app to_be_starred e es ret_atom
 
       | _ ->

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,3 +1,5 @@
+include ../Makefile.common
+
 RECENT_GCC	= $(shell [ "$$(gcc -dumpversion | cut -c -1)" -ge 5 ] && echo yes)
 
 ifeq (3.81,$(MAKE_VERSION))
@@ -22,7 +24,7 @@ endif
 ifneq ($(CRYPTO),)
   CRYPTO_OPTS	= -I $(CRYPTO) -I $(CRYPTO)/real
 endif
-TEST_OPTS	= -warn-error @4 -verbose -skip-makefiles
+TEST_OPTS	= -warn-error @4 -skip-makefiles
 KRML_BIN	= ../_build/default/src/Karamel.exe
 KRML		= $(KRML_BIN) -fstar $(FSTAR_EXE) $(KOPTS) $(TEST_OPTS)
 
@@ -95,11 +97,16 @@ everything: all
 
 # Use F*'s dependency mechanism and fill out the missing rules.
 
+comma := ,
+
 ifndef MAKE_RESTARTS
 ifndef NODEPEND
 .depend: .FORCE
-	$(FSTAR) --dep full $(subst .wasm-test,.fst,$(WASM_FILES)) $(subst .test,.fst,$(FILES)) \
-	  $(BROKEN) ../runtime/WasmSupport.fst --extract 'krml:*,-Prims' -o $@
+	$(call run-with-log, \
+	  $(FSTAR) --dep full $(subst .wasm-test,.fst,$(WASM_FILES)) $(subst .test,.fst,$(FILES)) \
+	    $(BROKEN) ../runtime/WasmSupport.fst --extract 'krml:*$(comma)-Prims' -o $@ \
+	  ,[DEPEND],\
+	  .depend)
 
 .PHONY: .FORCE
 .FORCE:
@@ -109,14 +116,16 @@ endif
 include .depend
 
 $(CACHE_DIR)/%.checked: | .depend
-	$(FSTAR) $(OTHERFLAGS) -c $< -o $@ && \
-	touch $@
+	$(call run-with-log,$(FSTAR) $(OTHERFLAGS) -c $< -o $@ && touch $@,[VERIFY] $*,$(CACHE_DIR)/$*)
 
 $(OUTPUT_DIR)/%.krml: | .depend
-	$(FSTAR) $(OTHERFLAGS) --codegen krml \
-	  --extract_module $(basename $(notdir $(subst .checked,,$<))) \
-	  -o $@ \
-	  $<
+	$(call run-with-log, \
+	  $(FSTAR) $(OTHERFLAGS) --codegen krml \
+	    --extract_module $(basename $(notdir $(subst .checked,,$<))) \
+	    -o $@ \
+	    $< \
+	 ,[EXTRACT] $*,\
+	  $(OUTPUT_DIR)/$*) 
 
 ###############
 # Regular (C) #
@@ -129,12 +138,14 @@ $(OUTPUT_DIR)/Ctypes2.exe: $(ALL_KRML_FILES) $(KRML_BIN)
 
 .PRECIOUS: $(OUTPUT_DIR)/%.exe
 $(OUTPUT_DIR)/%.exe: $(ALL_KRML_FILES) $(KRML_BIN)
-	$(KRML) $(EXTRA) -tmpdir $(subst .exe,.out,$@) -no-prefix $(notdir $*) \
-	  -o $@ $(filter %.krml,$^) -bundle $(subst _,.,$*)=WindowsHack,\*
+	$(call run-with-log, \
+	  $(KRML) $(EXTRA) -tmpdir $(subst .exe,.out,$@) -no-prefix $(notdir $*) \
+	    -o $@ $(filter %.krml,$^) -bundle $(subst _,.,$*)=WindowsHack$(comma)\* \
+	,[KRML] $*,$(OUTPUT_DIR)/$*)
 
 .SECONDEXPANSION:
 %.test: $(OUTPUT_DIR)/$$(notdir $$(subst .,_,$$*)).exe
-	@(if $(NEGATIVE); then ! $^; else $^; fi) && echo "\033[01;32m✔\033[00m [TEST,$*]" || (echo "\033[01;31m✘\033[00m [TEST,$*]" && false)
+	@(if $(NEGATIVE); then ! $^; else $^; fi) && echo -e "\033[01;32m✔\033[00m [TEST,$*]" || (echo -e "\033[01;31m✘\033[00m [TEST,$*]" && false)
 
 ifeq ($(OS),Windows_NT)
   HELLOSYSTEM_LDOPTS = -ldopts -lws2_32
@@ -172,7 +183,7 @@ $(OUTPUT_DIR)/Ctypes2.exe: EXTRA = -ctypes 'Ctypes2,Ctypes4' \
   -bundle 'Ctypes3+Ctypes4=[rename=Lowlevel]' \
   -bundle 'Ctypes2=' \
   -bundle 'Ctypes1=' \
-  -bundle '*,WindowsHack[rename=Leftovers]' \
+  -bundle '*$(comma)WindowsHack[rename=Leftovers]' \
   -no-prefix 'Ctypes4' -skip-compilation
 $(OUTPUT_DIR)/Failwith.exe: EXTRA = -ccopts -Wno-deprecated-declarations,-Wno-infinite-recursion
 $(OUTPUT_DIR)/VariableMerge.exe: EXTRA = -fmerge aggressive
@@ -286,11 +297,12 @@ $(LOWLEVEL_DIR)/Client.native: $(OUTPUT_DIR)/Ctypes2.exe $(addprefix $(LOWLEVEL_
 # NEGATIVE for negative tests.
 .PRECIOUS: $(OUTPUT_DIR)/%.wasm
 $(OUTPUT_DIR)/%.wasm: $(ALL_KRML_FILES) $(KRML_BIN)
-	$(KRML) -minimal -bundle WasmSupport= -bundle 'FStar.*' -bundle Prims \
+	$(call run-with-log,$(KRML) -minimal -bundle WasmSupport= -bundle 'FStar.*' -bundle Prims \
 	  -bundle C -bundle C.Endianness -bundle C.Nullity -bundle C.String \
 	  -bundle TestLib \
-	  -bundle $(subst _,.,$*)=WindowsHack,\* \
-	  -backend wasm $(EXTRA) -tmpdir $@ $(JSFILES) -no-prefix $* $(filter %.krml,$^)
+	  -bundle $(subst _,.,$*)=WindowsHack$(comma)\* \
+	  -backend wasm $(EXTRA) -tmpdir $@ $(JSFILES) -no-prefix $* $(filter %.krml,$^)\
+	  ,[KRML-WASM] $*,$(OUTPUT_DIR)/$*)
 	[ x$(JSFILES) != x ] && cp $(JSFILES) $@ || true
 
 %.wasm-test: $(OUTPUT_DIR)/%.wasm
@@ -309,8 +321,9 @@ WasmTrap.wasm-test: NEGATIVE = true
 
 .PRECIOUS: %.rs
 %.rs: $(ALL_KRML_FILES) $(KRML_BIN)
-	$(KRML) -minimal -bundle $(notdir $(subst rust,Rust,$*))=\* \
-	  -backend rust $(EXTRA) -tmpdir $(dir $@) $(filter %.krml,$^)
+	$(call run-with-log,$(KRML) -minimal -bundle $(notdir $(subst rust,Rust,$*))=\* \
+	  -backend rust $(EXTRA) -tmpdir $(dir $@) $(filter %.krml,$^)\
+	  ,[KRML-RS] $(basename $*),$*)
 	$(SED) -i 's/\(patterns..\)/\1\nmod lowstar { pub mod ignore { pub fn ignore<T>(_x: T) {}}}\n/' $@
 	echo 'fn main () { let r = main_ (); if r != 0 { println!("main_ returned: {}\\n", r); panic!() } }' >> $@
 

--- a/test/rust-val/Makefile
+++ b/test/rust-val/Makefile
@@ -1,3 +1,5 @@
+include ../../Makefile.common
+
 RECENT_GCC	= $(shell [ "$$(gcc -dumpversion | cut -c -1)" -ge 5 ] && echo yes)
 
 ifeq (3.81,$(MAKE_VERSION))
@@ -47,13 +49,14 @@ endif
 include .depend
 
 $(CACHE_DIR)/%.checked: | .depend
-	$(FSTAR) $(OTHERFLAGS) $< && \
+	$(call run-with-log,$(FSTAR) $(OTHERFLAGS) $< && \,[RUSTVAL_VERIFY] $*,$(CACHE_DIR)/$*)
 	touch $@
 
 %.krml: | .depend
-	$(FSTAR) $(OTHERFLAGS) --codegen krml \
+	$(call run-with-log,$(FSTAR) $(OTHERFLAGS) --codegen krml \
 	  --extract_module $(basename $(notdir $(subst .checked,,$<))) \
-	  $(notdir $(subst .checked,,$<))
+	  $(notdir $(subst .checked,,$<))\
+	  ,[RUSTVAL_EXTRACT_KRML] $(basename $*),$*)
 
 ########
 # Rust #

--- a/test/sepcomp/a/Makefile
+++ b/test/sepcomp/a/Makefile
@@ -1,3 +1,5 @@
+include ../../../Makefile.common
+
 #############################
 # This is the main Makefile #
 #############################
@@ -62,7 +64,9 @@ FSTAR_ROOTS = $(wildcard $(addsuffix /*.fsti,$(SOURCE_DIRS))) \
 ifndef MAKE_RESTARTS
 obj/.depend: .FORCE
 	mkdir -p obj
-	$(FSTAR_NO_FLAGS) --dep full $(notdir $(FSTAR_ROOTS)) $(FSTAR_EXTRACT) -o $@
+	$(call run-with-log,\
+	  $(FSTAR_NO_FLAGS) --dep full $(notdir $(FSTAR_ROOTS)) $(FSTAR_EXTRACT) -o $@\
+	  ,[SEPCOMP_DEPEND],obj/.depend)
 
 .PHONY: .FORCE
 .FORCE:
@@ -105,23 +109,29 @@ obj:
 # up-to-date (checksum matches, file unchanged), but this will confuse
 # make and result in endless rebuilds. So, we touch that file.
 %.checked: | obj
-	$(FSTAR) $(FSTAR_FLAGS) -c $< -o $@ && touch -c $@
+	$(call run-with-log,\
+	  $(FSTAR) $(FSTAR_FLAGS) -c $< -o $@ && touch -c $@\
+	  ,[SEPCOMP_VERIFY] $(basename $*),$*)
 
 # Extraction
 # ----------
 
 .PRECIOUS: obj/%.ml
 obj/%.ml:
-	$(FSTAR) $< --codegen OCaml
+	$(call run-with-log,\
+	  $(FSTAR) $< --codegen OCaml\
+	  ,[SEPCOMP_EXTRACT_OCAML] $(basename $*),$*)
 
 # By default, krml extraction in F* will extract every module into a
 # single out.krml file. Make sure to extract the single module we want
 # to get a single-properly named file.
 .PRECIOUS: obj/%.krml
 obj/%.krml:
-	$(FSTAR) $< --codegen krml \
-	--extract_module $(basename $(notdir $(subst .checked,,$<))) \
-	-o $@
+	$(call run-with-log,\
+	  $(FSTAR) $< --codegen krml \
+	  --extract_module $(basename $(notdir $(subst .checked,,$<))) \
+	  -o $@\
+	  ,[SEPCOMP_EXTRACT_KRML] $(basename $*),$*)
 
 # F* --> C
 # --------

--- a/test/sepcomp/b/Makefile
+++ b/test/sepcomp/b/Makefile
@@ -1,3 +1,5 @@
+include ../../../Makefile.common
+
 #############################
 # This is the main Makefile #
 #############################
@@ -64,7 +66,9 @@ FSTAR_ROOTS = $(wildcard $(addsuffix /*.fsti,$(SOURCE_DIRS))) \
 ifndef MAKE_RESTARTS
 obj/.depend: .FORCE
 	mkdir -p obj
-	$(FSTAR_NO_FLAGS) --dep full $(notdir $(FSTAR_ROOTS)) $(FSTAR_EXTRACT) -o $@
+	$(call run-with-log,\
+	  $(FSTAR_NO_FLAGS) --dep full $(notdir $(FSTAR_ROOTS)) $(FSTAR_EXTRACT) -o $@\
+	  ,[SEPCOMP_DEPEND],obj/.depend)
 
 .PHONY: .FORCE
 .FORCE:
@@ -107,23 +111,29 @@ obj:
 # up-to-date (checksum matches, file unchanged), but this will confuse
 # make and result in endless rebuilds. So, we touch that file.
 %.checked: | obj
-	$(FSTAR) $(FSTAR_FLAGS) -c $< -o $@ && touch -c $@
+	$(call run-with-log,\
+	  $(FSTAR) $(FSTAR_FLAGS) -c $< -o $@ && touch -c $@\
+	  ,[SEPCOMP_VERIFY] $(basename $*),$*)
 
 # Extraction
 # ----------
 
 .PRECIOUS: obj/%.ml
 obj/%.ml:
-	$(FSTAR) $< --codegen OCaml
+	$(call run-with-log,\
+	  $(FSTAR) $< --codegen OCaml\
+	  ,[SEPCOMP_EXTRACT_OCAML] $(basename $*),$*)
 
 # By default, krml extraction in F* will extract every module into a
 # single out.krml file. Make sure to extract the single module we want
 # to get a single-properly named file.
 .PRECIOUS: obj/%.krml
 obj/%.krml:
-	$(FSTAR) $< --codegen krml \
-	--extract_module $(basename $(notdir $(subst .checked,,$<))) \
-	-o $@
+	$(call run-with-log,\
+	  $(FSTAR) $< --codegen krml \
+	    --extract_module $(basename $(notdir $(subst .checked,,$<))) \
+	    -o $@\
+	  ,[SEPCOMP_EXTRACT_KRML] $(basename $*),$*)
 
 # F* --> C
 # --------


### PR DESCRIPTION
So that hopefully we won't hit the dread log output limit.

This reuses the function from HACL* which does a good job.