### PR TITLE
Enable optimize_let_vc

### DIFF
--- a/book/tutorial/Makefile
+++ b/book/tutorial/Makefile
@@ -48,7 +48,7 @@ FSTAR_EXTRACT = --extract 'OCaml:-* +Spec'
 #   inline_for_extraction in the presence of interfaces
 # - --cache_dir, to place checked files there
 
-FSTAR_NO_FLAGS = $(FSTAR_EXE) --ext context_pruning \
+FSTAR_NO_FLAGS = $(FSTAR_EXE) --ext optimize_let_vc \
   --odir obj $(FSTAR_INCLUDES) --cmi \
   --already_cached 'Prims FStar LowStar C Spec.Loops TestLib WasmSupport' --warn_error '+241@247+285' \
   --cache_dir obj

--- a/krmllib/Makefile
+++ b/krmllib/Makefile
@@ -24,7 +24,7 @@ UINT128_DIR = dist/uint128
 MINI_DIR = dist/minimal
 
 #332 is turning abstract keyword usage into a fatal error
-FSTAR_OPTIONS += --ext context_pruning --odir $(EXTRACT_DIR) \
+FSTAR_OPTIONS += --ext optimize_let_vc --odir $(EXTRACT_DIR) \
   --warn_error @332
   # --use_extracted_interfaces
 

--- a/krmllib/dist/generic/FStar_List_Tot_Base.h
+++ b/krmllib/dist/generic/FStar_List_Tot_Base.h
@@ -14,6 +14,8 @@
 
 typedef void *FStar_List_Tot_Base_memP;
 
+typedef void *FStar_List_Tot_Base_for_allP;
+
 typedef void *FStar_List_Tot_Base_no_repeats_p;
 
 typedef void *FStar_List_Tot_Base_strict_suffix_of;

--- a/test/Makefile
+++ b/test/Makefile
@@ -80,7 +80,7 @@ FSTAR		= $(FSTAR_EXE) \
   --cache_dir $(CACHE_DIR) --odir $(OUTPUT_DIR) \
   --include hello-system --include ../krmllib/compat --include ../krmllib/obj \
   --include ../krmllib --include ../runtime \
-  $(INCLUDE_CRYPTO) --include ../book --include ../book/notfslit --ext context_pruning \
+  $(INCLUDE_CRYPTO) --include ../book --include ../book/notfslit --ext optimize_let_vc \
   --already_cached 'Prims FStar C TestLib Spec.Loops -C.Compat -C.Nullity LowStar WasmSupport' \
   --trivial_pre_for_unannotated_effectful_fns false \
   --cmi --warn_error -274

--- a/test/rust-val/Makefile
+++ b/test/rust-val/Makefile
@@ -17,7 +17,7 @@ FSTAR		= $(FSTAR_EXE) --cache_checked_modules \
   --cache_dir $(CACHE_DIR) \
   --include ../../krmllib/compat --include ../../krmllib/obj \
   --include ../../krmllib --include ../../runtime \
-  --ext context_pruning \
+  --ext optimize_let_vc \
   --already_cached 'Prims FStar C TestLib Spec.Loops -C.Compat -C.Nullity LowStar WasmSupport' \
   --trivial_pre_for_unannotated_effectful_fns false \
   --cmi --warn_error -274

--- a/test/rust-val/impl/Makefile
+++ b/test/rust-val/impl/Makefile
@@ -16,7 +16,7 @@ FSTAR		= $(FSTAR_EXE) --cache_checked_modules \
   --include ../../../krmllib/compat --include ../../../krmllib/obj \
   --include ../../../krmllib --include ../../../runtime \
   --include .. \
-  --ext context_pruning \
+  --ext optimize_let_vc \
   --already_cached 'Prims FStar C TestLib Spec.Loops -C.Compat -C.Nullity LowStar WasmSupport' \
   --trivial_pre_for_unannotated_effectful_fns false \
   --cmi --warn_error -274


### PR DESCRIPTION
In preparation for F* PR https://github.com/FStarLang/FStar/pull/3861

No other changes required to Karamel to use this optimization.

Removed --ext context_pruning, since that's now the default in F*