### PR TITLE
CI: `opam update` before `opam install`

### DIFF
--- a/.docker/build/install-deps.sh
+++ b/.docker/build/install-deps.sh
@@ -16,6 +16,7 @@ fi
 # Install F*
 [[ -n "$FSTAR_HOME" ]]
 git clone --branch $FSTAR_BRANCH https://github.com/FStarLang/FStar "$FSTAR_HOME"
+opam update
 opam install --deps-only "$FSTAR_HOME/fstar.opam"
 OTHERFLAGS='--admit_smt_queries true' make -j 24 -C "$FSTAR_HOME"
 

--- a/.docker/build/install-other-deps.sh
+++ b/.docker/build/install-other-deps.sh
@@ -7,4 +7,5 @@ build_home="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd "$build_home/../.."
 
 grep -v '"fstar"' < karamel.opam > karamel-nofstar.opam
+opam update
 opam install --deps-only ./karamel-nofstar.opam


### PR DESCRIPTION
The nightly CI broke because F* now depends on sedlex 3.6, but `opam install` couldn't find it because the CI tasks building ocaml in the Dockerfile are cached and so `opam update` is never run.This PR changes that, by running `opam update` in the CI scripts that install the F* and Karamel opam dependencies.
