### PR TITLE
added support for float & double

### DIFF
--- a/include/krml/internal/types.h
+++ b/include/krml/internal/types.h
@@ -21,6 +21,8 @@ typedef uint16_t FStar_UInt16_t, FStar_UInt16_t_;
 typedef int16_t FStar_Int16_t, FStar_Int16_t_;
 typedef uint8_t FStar_UInt8_t, FStar_UInt8_t_;
 typedef int8_t FStar_Int8_t, FStar_Int8_t_;
+typedef float float32;
+typedef double float64;
 
 /* Only useful when building krmllib, because it's in the dependency graph of
  * FStar.Int.Cast. */

--- a/lib/CFlat.ml
+++ b/lib/CFlat.ml
@@ -60,9 +60,9 @@ module Sizes = struct
   let array_size_of_width (w: K.width) =
     let open K in
     match w with
-    | UInt64 | Int64 | CInt ->
+    | UInt64 | Int64 | CInt | Float64 ->
         A64
-    | UInt32 | Int32 ->
+    | UInt32 | Int32 | Float32 ->
         A32
     | UInt16 | Int16 ->
         A16

--- a/lib/Constant.ml
+++ b/lib/Constant.ml
@@ -8,10 +8,10 @@ type t = width * string
 
 and width =
   | UInt8 | UInt16 | UInt32 | UInt64 | Int8 | Int16 | Int32 | Int64
-  | Float32 | Float64 (** Floating point numbers. *)
   | Bool
   | CInt (** Checked signed integers. *)
   | SizeT | PtrdiffT
+  | Float32 | Float64 (** Floating point numbers. *)
 
 let bytes_of_width (w: width) =
   match w with

--- a/lib/Constant.ml
+++ b/lib/Constant.ml
@@ -66,9 +66,9 @@ let unsigned_of_signed = function
   | Float32 | Float64 -> raise (Invalid_argument "unsigned_of_signed")
 
 let is_signed = function
-  | Int8 | Int16 | Int32 | Int64 | CInt | PtrdiffT | Float32 | Float64 -> true
+  | Int8 | Int16 | Int32 | Int64 | CInt | PtrdiffT -> true
   | UInt8 | UInt16 | UInt32 | UInt64 | SizeT -> false
-  | Bool -> raise (Invalid_argument "is_signed")
+  | Bool | Float32 | Float64 -> raise (Invalid_argument "is_signed")
 
 let is_unsigned w = not (is_signed w)
 

--- a/lib/Constant.ml
+++ b/lib/Constant.ml
@@ -8,6 +8,7 @@ type t = width * string
 
 and width =
   | UInt8 | UInt16 | UInt32 | UInt64 | Int8 | Int16 | Int32 | Int64
+  | Float32 | Float64 (** Floating point numbers. *)
   | Bool
   | CInt (** Checked signed integers. *)
   | SizeT | PtrdiffT
@@ -61,10 +62,11 @@ let unsigned_of_signed = function
   | Int16 -> UInt16
   | Int32 -> UInt32
   | Int64 -> UInt64
-  | CInt | UInt8 | UInt16 | UInt32 | UInt64 | SizeT | PtrdiffT | Bool -> raise (Invalid_argument "unsigned_of_signed")
+  | CInt | UInt8 | UInt16 | UInt32 | UInt64 | SizeT | PtrdiffT | Bool
+  | Float32 | Float64 -> raise (Invalid_argument "unsigned_of_signed")
 
 let is_signed = function
-  | Int8 | Int16 | Int32 | Int64 | CInt | PtrdiffT -> true
+  | Int8 | Int16 | Int32 | Int64 | CInt | PtrdiffT | Float32 | Float64 -> true
   | UInt8 | UInt16 | UInt32 | UInt64 | SizeT -> false
   | Bool -> raise (Invalid_argument "is_signed")
 

--- a/lib/PrintCommon.ml
+++ b/lib/PrintCommon.ml
@@ -33,6 +33,8 @@ let width_to_string = function
   | Bool -> "bool"
   | SizeT -> if !Options.linux_ints then "size_t" else "size"
   | PtrdiffT -> if !Options.linux_ints then "ptrdiff_t" else "ptrdiff"
+  | Float32 -> "float32"
+  | Float64 -> "float64"
 
 let print_width w =
   string (width_to_string w) ^^

--- a/lib/PrintMiniRust.ml
+++ b/lib/PrintMiniRust.ml
@@ -171,6 +171,8 @@ let string_of_width (w: Constant.width) =
   | Constant.SizeT -> "usize"
   | Constant.CInt -> ""
   | Constant.PtrdiffT -> failwith "unexpected: ptrdifft"
+  | Constant.Float32 -> "f32"
+  | Constant.Float64 -> "f64"
 
 let print_borrow_kind k =
   match k with


### PR DESCRIPTION
As the title, support for float & double, namely, `Float32` and `Float64` are added to the `Constant.ml`. Relevant parts are fixed. This is required from the project [Eurydice](https://github.com/AeneasVerif/eurydice).

Question left: where to add the `float32_t` and `float_64_t` definitions? Just adding to Eurydice is fine, but if this is not defined, Krml might be less self-contained.