### PR TITLE
Fix to an example, anticipating an F* update

### DIFF
--- a/krmllib/LowStar.Lib.AssocList.fst
+++ b/krmllib/LowStar.Lib.AssocList.fst
@@ -179,11 +179,13 @@ let rec remove_all_ #t_k #t_v hd l k =
   end
 #pop-options
 
+#push-options "--fuel 1"
 let remove_all #_ #_ ll k =
   let open LL2 in
   let hd, v = remove_all_ !*ll.ptr !*ll.v k in
   ll.ptr *= hd;
   ll.v *= v
+#pop-options
 
 /// Clearing (resetting)
 /// --------------------


### PR DESCRIPTION
An upcoming update to F*'s SMT encoding reveals that this example actually needs one unit of fuel to pass (to unfold LL1.well_formed).