### PR TITLE
Fixed Eurydice error on floating point

### DIFF
--- a/lib/Ast.ml
+++ b/lib/Ast.ml
@@ -67,6 +67,8 @@ and type_scheme = {
 (* The visitor of types composes with the misc. visitor. *)
 and typ =
   | TInt of width
+      (** this constructor includes also **floating points** for historical
+       * reason. *)
   | TBool
   | TUnit
   | TAny

--- a/lib/Constant.ml
+++ b/lib/Constant.ml
@@ -67,8 +67,8 @@ let unsigned_of_signed = function
 
 let is_signed = function
   | Int8 | Int16 | Int32 | Int64 | CInt | PtrdiffT -> true
-  | UInt8 | UInt16 | UInt32 | UInt64 | SizeT -> false
-  | Bool | Float32 | Float64 -> raise (Invalid_argument "is_signed")
+  | UInt8 | UInt16 | UInt32 | UInt64 | SizeT | Float32 | Float64 -> false
+  | Bool -> raise (Invalid_argument "is_signed")
 
 let is_unsigned w = not (is_signed w)
 

--- a/lib/Constant.ml
+++ b/lib/Constant.ml
@@ -67,8 +67,8 @@ let unsigned_of_signed = function
 
 let is_signed = function
   | Int8 | Int16 | Int32 | Int64 | CInt | PtrdiffT -> true
-  | UInt8 | UInt16 | UInt32 | UInt64 | SizeT | Float32 | Float64 -> false
-  | Bool -> raise (Invalid_argument "is_signed")
+  | UInt8 | UInt16 | UInt32 | UInt64 | SizeT -> false
+  | Bool | Float32 | Float64 -> raise (Invalid_argument "is_signed")
 
 let is_unsigned w = not (is_signed w)
 


### PR DESCRIPTION
During the C* -> C11 translation, `is_signed` will be called on floating point, and we should not raise error for that. This PR fixed that.