### PR TITLE
rename to pass Eurydice test

### DIFF
--- a/include/krml/internal/target.h
+++ b/include/krml/internal/target.h
@@ -12,6 +12,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+typedef float float32_t;
+typedef double float64_t;
+
 /* Since KaRaMeL emits the inline keyword unconditionally, we follow the
  * guidelines at https://gcc.gnu.org/onlinedocs/gcc/Inline.html and make this
  * __inline__ to ensure the code compiles with -std=c90 and earlier. */

--- a/include/krml/internal/types.h
+++ b/include/krml/internal/types.h
@@ -21,8 +21,6 @@ typedef uint16_t FStar_UInt16_t, FStar_UInt16_t_;
 typedef int16_t FStar_Int16_t, FStar_Int16_t_;
 typedef uint8_t FStar_UInt8_t, FStar_UInt8_t_;
 typedef int8_t FStar_Int8_t, FStar_Int8_t_;
-typedef float float32;
-typedef double float64;
 
 /* Only useful when building krmllib, because it's in the dependency graph of
  * FStar.Int.Cast. */


### PR DESCRIPTION
The type name should be `float32_t` and `float64_t` instead of `float32` and `float64` --- as generated in Eurydice.