### PR TITLE
Introduce -dbt: print a backtrace on an error

### DIFF
--- a/lib/AstToCFlat.ml
+++ b/lib/AstToCFlat.ml
@@ -382,7 +382,7 @@ let populate env files =
           with e ->
             KPrint.beprintf "[AstToC♭] can't compute the layout of %a:\n%s\n%s"
               PrintAst.plid lid (Printexc.to_string e)
-              (if Options.debug "backtraces" then Printexc.get_backtrace () ^ "\n" else "");
+              (if !Options.backtrace then Printexc.get_backtrace () ^ "\n" else "");
             env
           end
       | _ ->
@@ -709,9 +709,8 @@ and mk_expr_or_bail (env: env) (locals: locals) (e: expr): locals * CF.expr =
         Hashtbl.replace errors !current_lid (s :: Hashtbl.find errors !current_lid)
       else
         Hashtbl.add errors !current_lid [ s ];
-      let bt = if Options.debug "backtraces" then Printexc.get_backtrace () ^ "\n" else "" in
-      let msg = KPrint.bsprintf "%a: compilation error turned to runtime failure\n%s%s"
-        plid !current_lid s bt
+      let msg = KPrint.bsprintf "%a: compilation error turned to runtime failure\n%s"
+        plid !current_lid s
       in
       mk_expr env locals (Helpers.with_unit (EAbort (None, Some msg)))
 
@@ -1125,7 +1124,7 @@ let mk_module env decls =
       flush stderr;
       KPrint.beprintf "[AstToC♭] skipping %s%a%s:\n%s\n%s"
         Ansi.underline PrintAst.plid (lid_of_decl d) Ansi.reset (Printexc.to_string e)
-        (if Options.debug "backtraces" then Printexc.get_backtrace () ^ "\n" else "");
+        (if !Options.backtrace then Printexc.get_backtrace () ^ "\n" else "");
       env, decls
   ) (env, []) decls in
   env, List.rev decls

--- a/lib/AstToCStar.ml
+++ b/lib/AstToCStar.ml
@@ -993,12 +993,12 @@ and mk_program m name env decls =
     let n = string_of_lident (Ast.lid_of_decl d) in
     match mk_declaration m { env with type_names = names } d with
     | exception (Error e) ->
-        if Options.debug "backtraces" then
+        if !Options.backtrace then
           Printexc.print_backtrace stdout;
         Warn.maybe_fatal_error (fst e, Dropping (name ^ "/" ^ n, e));
         decls, names
     | exception e ->
-        if Options.debug "backtraces" then
+        if !Options.backtrace then
           Printexc.print_backtrace stdout;
         Warn.fatal_error "Fatal failure in %a: %s\n"
           plid (Ast.lid_of_decl d)

--- a/lib/Checker.ml
+++ b/lib/Checker.ml
@@ -173,7 +173,7 @@ and check_program env r (name, decls) =
     | CheckerError e ->
         r := true;
         flush stdout;
-        if Options.debug "backtraces" then
+        if !Options.backtrace then
           Printexc.print_backtrace stderr;
         KPrint.beprintf "Cannot re-check %a as valid Low* and will not extract it.  \
           If %a is not meant to be extracted, consider marking it as Ghost, \

--- a/lib/Options.ml
+++ b/lib/Options.ml
@@ -66,6 +66,7 @@ let library: Bundle.pat list ref = ref []
 let hand_written: Bundle.pat list ref = ref []
 let debug_modules: string list ref = ref []
 let debug s = List.exists ((=) s) !debug_modules
+let backtrace : bool ref = ref false
 
 type backend = C | Rust | Wasm
 let backend = ref C

--- a/lib/Warn.ml
+++ b/lib/Warn.ml
@@ -229,6 +229,8 @@ let maybe_fatal_error error =
   | CError ->
       KPrint.beprintf "%a" perr error;
       KPrint.beprintf "Warning %d is fatal, exiting.\n" errno;
+      if !Options.backtrace then
+        KPrint.beprintf "Stack trace:\n%s\n" (Printexc.get_backtrace ());
       exit 255
   | CWarning ->
       if not (S.mem error !emitted_warnings) then begin

--- a/src/Karamel.ml
+++ b/src/Karamel.ml
@@ -374,6 +374,9 @@ Supported options:|}
       struct transformations";
     "-dc", Arg.Set arg_print_c, " pretty-print the output C";
     "-dwasm", Arg.Set arg_print_wasm, " pretty-print the output Wasm";
+    "-dbacktrace", Arg.Unit (fun () ->
+       Printexc.record_backtrace true;
+       Options.backtrace := true), " print a stack trace on errors";
     "-d", Arg.String (csv (prepend Options.debug_modules)), " debug the specific \
       comma-separated list of values; currently supported: \
       inline,bundle,reachability,c-calls,c-names,wasm-calls,wasm-memory,wasm,force-c,cflat";


### PR DESCRIPTION
This allows to pass -dbt to get a stack trace on an error:
```
$ krml -dbt [..] foo.krml
[...]
This is not a buffer: any
Warning 4 is fatal, exiting.
Stack trace:
Raised at Krml__Checker.checker_error.(fun) in file "lib/Checker.ml", line 85, characters 4-104
Called from Krml__Checker.infer' in file "lib/Checker.ml", line 700, characters 18-37
Called from Krml__Checker.infer in file "lib/Checker.ml", line 527, characters 10-22
Called from Stdlib__List.map in file "list.ml", line 86, characters 15-19
Called from Krml__Checker.infer' in file "lib/Checker.ml", line 776, characters 13-38
Called from Krml__Checker.infer in file "lib/Checker.ml", line 527, characters 10-22
Called from Krml__Checker.infer' in file "lib/Checker.ml", line 638, characters 13-26
Called from Krml__Checker.infer in file "lib/Checker.ml", line 527, characters 10-22
Called from Stdlib__List.map in file "list.ml", line 83, characters 15-19
Called from Krml__Checker.infer' in file "lib/Checker.ml", line 649, characters 16-39
Called from Krml__Checker.infer in file "lib/Checker.ml", line 527, characters 10-22
Called from Krml__Checker.check' in file "lib/Checker.ml", line 335, characters 8-21
Called from Krml__Checker.check in file "lib/Checker.ml", line 278, characters 2-16
Called from Krml__Checker.check_or_infer in file "lib/Checker.ml", line 228, characters 4-17
Called from Krml__Checker.check' in file "lib/Checker.ml", line 343, characters 15-80
Called from Krml__Checker.check in file "lib/Checker.ml", line 278, characters 2-16
Called from Krml__Checker.infer' in file "lib/Checker.ml", line 836, characters 6-23
Called from Krml__Checker.infer in file "lib/Checker.ml", line 527, characters 10-22
Called from Krml__Checker.infer' in file "lib/Checker.ml", line 647, characters 14-25
Called from Krml__Checker.infer in file "lib/Checker.ml", line 527, characters 10-22
Called from Krml__Checker.check' in file "lib/Checker.ml", line 335, characters 8-21
Called from Krml__Checker.check in file "lib/Checker.ml", line 278, characters 2-16
Called from Krml__Checker.check_program.(fun) in file "lib/Checker.ml", line 170, characters 6-22
```

For uncaught errors, setting `OCAMLRUNPARAM=b` already had the same effect (though one must remember this instead of being an actual option). This option makes it also easy to get stack traces for caught errors like warning 4 above.