### PR TITLE
Substitute cgs before types for all cases in Checker.ml

### DIFF
--- a/lib/Checker.ml
+++ b/lib/Checker.ml
@@ -465,14 +465,14 @@ and check' env t e =
       | lid, ts, cgs when kind env lid = Some Record ->
           let fieldtyps = assert_flat env (lookup_type env lid) in
           let fieldtyps = List.map (fun (field, (typ, m)) ->
-            field, (DeBruijn.subst_tn ts (DeBrujin.subst_ctn' cgs typ), m)
+            field, (DeBruijn.subst_tn ts (DeBruijn.subst_ctn' cgs typ), m)
           ) fieldtyps in
           check_fields_opt env fieldexprs fieldtyps
 
       | lid, ts, cgs when kind env lid = Some Union ->
           let fieldtyps = assert_union env (lookup_type env lid) in
           let fieldtyps = List.map (fun (field, typ) ->
-            field, DeBruijn.subst_tn ts (DeBrujin.subst_ctn' cgs typ)
+            field, DeBruijn.subst_tn ts (DeBruijn.subst_ctn' cgs typ)
           ) fieldtyps in
           check_union env fieldexprs fieldtyps
 

--- a/lib/Checker.ml
+++ b/lib/Checker.ml
@@ -472,7 +472,7 @@ and check' env t e =
       | lid, ts, cgs when kind env lid = Some Union ->
           let fieldtyps = assert_union env (lookup_type env lid) in
           let fieldtyps = List.map (fun (field, typ) ->
-            field, (DeBruijn.subst_tn ts (DeBrujin.subst_ctn' cgs typ)
+            field, DeBruijn.subst_tn ts (DeBrujin.subst_ctn' cgs typ)
           ) fieldtyps in
           check_union env fieldexprs fieldtyps
 

--- a/lib/Checker.ml
+++ b/lib/Checker.ml
@@ -465,14 +465,14 @@ and check' env t e =
       | lid, ts, cgs when kind env lid = Some Record ->
           let fieldtyps = assert_flat env (lookup_type env lid) in
           let fieldtyps = List.map (fun (field, (typ, m)) ->
-            field, (DeBruijn.subst_ctn' cgs (DeBruijn.subst_tn ts typ), m)
+            field, (DeBruijn.subst_tn ts (DeBrujin.subst_ctn' cgs typ), m)
           ) fieldtyps in
           check_fields_opt env fieldexprs fieldtyps
 
       | lid, ts, cgs when kind env lid = Some Union ->
           let fieldtyps = assert_union env (lookup_type env lid) in
           let fieldtyps = List.map (fun (field, typ) ->
-            field, DeBruijn.subst_ctn' cgs (DeBruijn.subst_tn ts typ)
+            field, (DeBruijn.subst_tn ts (DeBrujin.subst_ctn' cgs typ)
           ) fieldtyps in
           check_union env fieldexprs fieldtyps
 
@@ -876,7 +876,7 @@ and find_field env t field =
       end
   | lid, ts, cgs ->
       let t, mut = find_field_from_def env (lookup_type env lid) field in
-      Some (DeBruijn.(subst_ctn' cgs (subst_tn ts t), mut))
+      Some (DeBruijn.(subst_tn ts (subst_ctn' cgs t), mut))
 
 and find_field_from_def env def field =
   try begin match def with


### PR DESCRIPTION
In the following code : 
https://github.com/FStarLang/karamel/blob/d3f05e518a1d9aeee3acfa596c5bf205d6383cb0/lib/Checker.ml#L867-L879

I think we should substitute the cgs before the types. Because the types may include cgs comming from the current env, which maybe subtituted again by `subst_ctn'`. Thus cause a type mismatch fail. This actually happens when I testing the `[T;C] -> arr<T,C>` translation of arrays in Eurydice on the test case 'where_clauses_fncg.rs'.

I notice that here you actually runs `subst_ctn` before `subst_tn` with some debug infos:

https://github.com/FStarLang/karamel/blob/d3f05e518a1d9aeee3acfa596c5bf205d6383cb0/lib/Checker.ml#L588-L595

So I guess that maybe you've once triggered this bug and fixed it here. But the other cases in this file are not changed. This's why I open this PR for changing all other substitution orders instead of opening an issue.

