### PR TITLE
Improve name management

### DIFF
--- a/lib/AstToCFlat.ml
+++ b/lib/AstToCFlat.ml
@@ -174,7 +174,7 @@ let rec runtime_type (env: env) (t: typ): runtime_type =
           Unknown
       | LEnum -> Int A32
       | LBuiltin (_, s) -> Int s
-      | _ -> Layout (GlobalNames.to_c_name env.names lid)
+      | _ -> Layout (GlobalNames.to_c_name env.names (lid, Type))
       end
   | TAnonymous (Union branches) ->
       Union (List.map (fun (_, t) -> runtime_type env t) branches)
@@ -548,11 +548,11 @@ let write_static (env: env) (lid: lident) (e: expr): string * CFlat.expr list =
         ) fields
     | EString s ->
         write_le dst ofs Helpers.uint32 (Z.of_int (Hashtbl.hash s));
-        let name = GlobalNames.to_c_name env.names lid in
+        let name = GlobalNames.to_c_name env.names (lid, Other) in
         [ CF.BufWrite (CF.GetGlobal name, ofs, CF.StringLiteral s, A32) ]
     | EQualified lid' ->
-        let name = GlobalNames.to_c_name env.names lid in
-        let name' = GlobalNames.to_c_name env.names lid' in
+        let name = GlobalNames.to_c_name env.names (lid, Other) in
+        let name' = GlobalNames.to_c_name env.names (lid', Other) in
         (* This is to disable constant string initializers sharing -- we write a
          * dummy value. *)
         write_le dst ofs Helpers.uint32 (Z.of_int (Hashtbl.hash name'));
@@ -661,7 +661,7 @@ and mk_addr env e =
       | TBuf _ -> ()
       | TQualified lid -> assert (is_lflat (LidMap.find lid env.layouts))
       | _ -> () end;
-      let name = GlobalNames.to_c_name env.names lid in
+      let name = GlobalNames.to_c_name env.names (lid, Other) in
       CF.GetGlobal name
   | EAbort _ ->
       mk_expr_no_locals env e
@@ -757,7 +757,7 @@ and mk_expr (env: env) (locals: locals) (e: expr): locals * CF.expr =
 
   | EApp ({ node = EQualified ident; _ }, es) ->
       let locals, es = fold (mk_expr env) locals es in
-      locals, CF.CallFunc (GlobalNames.to_c_name env.names ident, es)
+      locals, CF.CallFunc (GlobalNames.to_c_name env.names (ident, Other), es)
 
   | EApp _ ->
       failwith "unsupported application"
@@ -769,7 +769,7 @@ and mk_expr (env: env) (locals: locals) (e: expr): locals * CF.expr =
       locals, CF.Constant (K.UInt32, string_of_int (LidMap.find v env.enums))
 
   | EQualified v ->
-      locals, CF.GetGlobal (GlobalNames.to_c_name env.names v)
+      locals, CF.GetGlobal (GlobalNames.to_c_name env.names (v, Other))
 
   | EBufCreate (l, e_init, e_len) ->
       if not (e_init.node = EAny) then
@@ -1036,7 +1036,7 @@ let mk_decl env (d: decl): env * CF.decl list =
       ) ([], env) args in
       let locals = List.rev_append scratch_locals locals in
       current_lid := name;
-      let name = GlobalNames.to_c_name env.names name in
+      let name = GlobalNames.to_c_name env.names (name, Other) in
 
       (* Interlude: generate a wrapper, possibly *)
       let wrapper () = mk_wrapper name (List.length args) locals in
@@ -1072,13 +1072,13 @@ let mk_decl env (d: decl): env * CF.decl list =
         env, []
       end else
         let env, body, post_init = mk_global env name body in
-        let name = GlobalNames.to_c_name env.names name in
+        let name = GlobalNames.to_c_name env.names (name, Other) in
         env, [
           CF.Global (name, size, body, post_init, public)
         ]
 
   | DExternal (_, _, _, _, lid, t, _) ->
-      let name = GlobalNames.to_c_name env.names lid in
+      let name = GlobalNames.to_c_name env.names (lid, Other) in
       match t with
       | TArrow _ ->
           let ret, args = Helpers.flatten_arrow t in
@@ -1131,7 +1131,7 @@ let mk_module env decls =
 
 let mk_layouts env =
   `Assoc (LidMap.fold (fun lid layout acc ->
-    (GlobalNames.to_c_name env.names lid, layout_to_yojson layout) :: acc
+    (GlobalNames.to_c_name env.names (lid, Type), layout_to_yojson layout) :: acc
   ) env.layouts [])
 
 let report_failures () =

--- a/lib/AstToCStar.ml
+++ b/lib/AstToCStar.ml
@@ -953,10 +953,10 @@ and mk_declaration m env d: (CStar.decl * _) option =
         Some (CStar.External (name, add_cc (mk_type env t), flags, pp), [])
 
   | DType (name, flags, _, _, Forward k) ->
-      Some (CStar.TypeForward (name, flags, k), [ GlobalNames.to_c_name m name ])
+      Some (CStar.TypeForward (name, flags, k), [ GlobalNames.to_c_name m (name, Type) ])
 
   | DType (name, flags, 0, 0, def) ->
-      Some (CStar.Type (name, mk_type_def env def, flags), [ GlobalNames.to_c_name m name ] )
+      Some (CStar.Type (name, mk_type_def env def, flags), [ GlobalNames.to_c_name m (name, Type) ] )
 
   | DType _ ->
       None
@@ -977,6 +977,7 @@ and mk_type_def env d: CStar.typ =
       failwith "Variant should've been desugared at this stage"
 
   | Enum tags ->
+      (* TODO run through GlobalNames here?? *)
       CStar.Enum tags
 
   | Union fields ->

--- a/lib/AstToCStar.ml
+++ b/lib/AstToCStar.ml
@@ -953,6 +953,8 @@ and mk_declaration m env d: (CStar.decl * _) option =
         Some (CStar.External (name, add_cc (mk_type env t), flags, pp), [])
 
   | DType (name, flags, _, _, Forward k) ->
+      (* XXX why is every other name converted to a C name in CStarToC11, except for these two cases
+         here? *)
       Some (CStar.TypeForward (name, flags, k), [ GlobalNames.to_c_name m (name, Type) ])
 
   | DType (name, flags, 0, 0, def) ->
@@ -977,7 +979,6 @@ and mk_type_def env d: CStar.typ =
       failwith "Variant should've been desugared at this stage"
 
   | Enum tags ->
-      (* TODO run through GlobalNames here?? *)
       CStar.Enum tags
 
   | Union fields ->

--- a/lib/CStarToC11.ml
+++ b/lib/CStarToC11.ml
@@ -1399,7 +1399,7 @@ let mk_type_or_external m (w: where) ?(is_inline_static=false) (d: decl): C.decl
               else
                 failwith "TODO: support for negative enum values"
             in
-            let cases = List.map (fun (lid, v) -> to_c_name m (lid, Other), v) cases in
+            let cases = List.map (fun (lid, v) -> to_c_name m (lid, Macro), v) cases in
             wrap_verbatim name flags (Text (enum_as_macros cases)) @
             let qs, spec, decl = mk_spec_and_declarator_t m name (Int t) in
             [ Decl ([], (qs, spec, None, Some Typedef, { maybe_unused = false; target = None }, [ decl, None, None ]))]
@@ -1497,7 +1497,7 @@ let if_header_inline_static m f1 f2 d =
   let is_inline_static =
     List.exists (fun p ->
       (* Only things that end up in headers are in the reverse-map. *)
-      (Hashtbl.mem m (lid, GlobalNames.Other) || Hashtbl.mem m (lid, GlobalNames.Type)) &&
+      (Hashtbl.mem m (lid, GlobalNames.Other) || Hashtbl.mem m (lid, GlobalNames.Type) || Hashtbl.mem m (lid, GlobalNames.Macro)) &&
       Bundle.pattern_matches_lid p lid)
     !Options.static_header ||
     List.mem lid [

--- a/lib/GenCtypes.ml
+++ b/lib/GenCtypes.ml
@@ -77,7 +77,7 @@ let mk_simple_app_decl (name: ident) (typ: ident option) (head: ident)
  * -no-prefix options. If this is the beginning of a top-level name, lower is
  * true and we force the first letter to be lowercase_ascii to abide by OCaml syntax
  * restrictions. *)
-let mk_unqual_name m (n: A.lident) =
+let mk_unqual_name m (n: A.lident * GlobalNames.kind) =
   let n = GlobalNames.to_c_name m n in
   if Char.lowercase_ascii n.[0] <> n.[0] then
     String.make 1 (Char.lowercase_ascii n.[0]) ^ String.sub n 1 (String.length n - 1)
@@ -145,7 +145,7 @@ let mk_struct_manifest (k: structured) t =
 let mk_qualified_type m (typ: A.lident) =
   (* m is for debug only *)
   try exp_ident (Hashtbl.find special_types typ)
-  with Not_found -> exp_ident (mk_unqual_name m typ)
+  with Not_found -> exp_ident (mk_unqual_name m (typ, Type))
 
 let rec mk_typ ?(bytes=false) m = function
   | Int w -> exp_ident (PrintCommon.width_to_string w ^ "_t")
@@ -179,7 +179,7 @@ and mk_extern_decl m name keyword typ: structure_item =
  *   let point_y = field point "y" uint32_t
  *   let _ = seal point *)
 and mk_struct_decl ?(sealed=true) m (k: structured) (name: A.lident) fields: structure_item list =
-  let unqual_name = mk_unqual_name m name in
+  let unqual_name = mk_unqual_name m (name, Type) in
   let tm = mk_struct_manifest k unqual_name in
   let ctypes_structure =
     let struct_name = match k with
@@ -189,7 +189,7 @@ and mk_struct_decl ?(sealed=true) m (k: structured) (name: A.lident) fields: str
       | Struct ->
           mk_struct_name name
     in
-    let struct_name = GlobalNames.to_c_name m struct_name in
+    let struct_name = GlobalNames.to_c_name m (struct_name, Type) in
     let t = Typ.mk (Ptyp_constr (mk_ident "typ", [tm])) in
     let e = mk_app (exp_ident (structured_kw k)) [mk_const struct_name] in
     let p = Pat.mk (Ppat_var (mk_sym unqual_name)) in
@@ -226,7 +226,7 @@ and mk_struct_decl ?(sealed=true) m (k: structured) (name: A.lident) fields: str
 and mk_typedef m name typ =
   let type_const = match typ with
     | Int Constant.UInt8 -> Typ.mk (Ptyp_constr (mk_ident "Unsigned.UInt8.t", []))
-    | Qualified t -> Typ.mk (Ptyp_constr (mk_ident (mk_unqual_name m t), []))
+    | Qualified t -> Typ.mk (Ptyp_constr (mk_ident (mk_unqual_name m (t, Type)), []))
     | _ -> Warn.fatal_error "Unreachable"
   in
   let typ_name = mk_unqual_name m name in
@@ -278,16 +278,16 @@ let mk_ctypes_decl m (d: decl): structure =
       (* Don't generate bindings for projectors and internal names *)
       if not (KString.starts_with (snd name) "__proj__") &&
          not (KString.starts_with (snd name) "uu___") then
-        [build_binding m name return_type parameters]
+        [build_binding m (name, Other) return_type parameters]
       else
         []
   | Type (name, typ, _) -> begin
       match typ with
       | Struct fields  -> mk_struct_decl m Struct name fields
       | Enum tags ->
-          let tags = List.map (GlobalNames.to_c_name m) (List.map fst tags) in
-          (mk_typedef m name (Int Constant.UInt8)) @ (mk_enum_tags m name tags)
-      | Qualified t -> mk_typedef m name (Qualified t)
+          let tags = List.map (fun lid -> GlobalNames.to_c_name m (lid, Other)) (List.map fst tags) in
+          (mk_typedef m (name, Type) (Int Constant.UInt8)) @ (mk_enum_tags m (name, Type) tags)
+      | Qualified t -> mk_typedef m (name, Type) (Qualified t)
       | _ -> []
       end
   | Global (name, _, flags, typ, _) -> begin
@@ -296,11 +296,11 @@ let mk_ctypes_decl m (d: decl): structure =
       else
         match typ with
         | Function _ ->
-          [mk_extern_decl m name "foreign" typ]
+          [mk_extern_decl m (name, Other) "foreign" typ]
         | Pointer _ ->
           warn_drop_declaration "" (lid_of_decl d) ([], "extern *");
           []
-        | _ -> [mk_extern_decl m name "foreign_value" typ]
+        | _ -> [mk_extern_decl m (name, Other) "foreign_value" typ]
         end
   | External _
   | TypeForward _ -> []

--- a/lib/GlobalNames.ml
+++ b/lib/GlobalNames.ml
@@ -319,14 +319,14 @@ let target_c_name ~attempt_shortening ?(kind=Other) lid =
 let to_c_name m (lid, kind) =
   try
     (* If a regular identifier is not found, it may be the case that it was registered as a macro. *)
-    let lid = if false && not (Hashtbl.mem m (lid, kind)) && kind = Other then lid, Macro else lid, kind in
+    let lid = if not (Hashtbl.mem m (lid, kind)) && kind = Other then lid, Macro else lid, kind in
     let r = fst (Hashtbl.find m lid) in
-    KPrint.bprintf "%a --> %s\n" plid (fst lid) r;
+    (* KPrint.bprintf "%a --> %s\n" plid (fst lid) r; *)
     r
   with Not_found ->
     (* Note: this happens for external types which are not retained as DType
        nodes and therefore are not recorded in the initial name-assignment
        phase. *)
     let r = Idents.to_c_identifier (fst (target_c_name ~kind ~attempt_shortening:false lid)) in
-    KPrint.bprintf "%a !!! %s\n" plid lid r;
+    (* KPrint.bprintf "%a !!! %s\n" plid lid r; *)
     r

--- a/lib/GlobalNames.ml
+++ b/lib/GlobalNames.ml
@@ -8,16 +8,36 @@ open Idents
 open Ast
 open PrintAst.Ops
 
-type mapping = (lident, string * bool) Hashtbl.t
-type t = mapping * (string, unit) Hashtbl.t
+type kind = Macro | Type | Other
+
+type mapping = (lident * kind, string * bool) Hashtbl.t
+
+type used = {
+  macros: (string, unit) Hashtbl.t;
+  types: (string, unit) Hashtbl.t;
+  other: (string, unit) Hashtbl.t;
+}
+
+let used used = function
+  | Macro -> used.macros
+  | Type -> used.types
+  | Other -> used.other
+
+type t = mapping * used
 
 let dump (env: t) =
-  Hashtbl.iter (fun lident (c_name, nm) ->
+  Hashtbl.iter (fun (lident, _kind) (c_name, nm) ->
     KPrint.bprintf "%a --> %s%s\n" plid lident c_name (if nm then " (!)" else "")
   ) (fst env);
   Hashtbl.iter (fun c_name _ ->
-    KPrint.bprintf "%s is used\n" c_name
-  ) (snd env)
+    KPrint.bprintf "%s is a macro\n" c_name
+  ) (snd env).macros;
+  Hashtbl.iter (fun c_name _ ->
+    KPrint.bprintf "%s is a type\n" c_name
+  ) (snd env).types;
+  Hashtbl.iter (fun c_name _ ->
+    KPrint.bprintf "%s is an other\n" c_name
+  ) (snd env).other
 
 let keywords = [
   "_Alignas";
@@ -142,23 +162,41 @@ let reserve_keywords used_c_names =
 
 let create () =
   let c_of_original = Hashtbl.create 41 in
-  let used_c_names: (string, unit) Hashtbl.t = Hashtbl.create 41 in
-  reserve_keywords used_c_names;
+  let used_c_names: used = {
+    macros = Hashtbl.create 41;
+    types = Hashtbl.create 41;
+    other = Hashtbl.create 41;
+  } in
+  reserve_keywords used_c_names.macros;
+  reserve_keywords used_c_names.types;
+  reserve_keywords used_c_names.other;
   c_of_original, used_c_names
 
 let extend (global: t) (local: t) is_local original_name (desired_name, non_modular_renaming) =
   let c_of_original, g_used_c_names = global in
   let _, l_used_c_names = local in
   if Hashtbl.mem c_of_original original_name then
-    fatal_error "Duplicate global name: %a" plid original_name;
+    fatal_error "Duplicate global name in identical namespace: %a" plid (fst original_name);
+
+  let kind = snd original_name in
+  let conflicts_macros x = Hashtbl.mem g_used_c_names.macros x || Hashtbl.mem l_used_c_names.macros x in
+  let conflicts_types x = Hashtbl.mem g_used_c_names.types x || Hashtbl.mem l_used_c_names.types x in
+  let conflicts_other x = Hashtbl.mem g_used_c_names.other x || Hashtbl.mem l_used_c_names.other x in
 
   let unique_c_name = mk_fresh desired_name (fun x ->
-    Hashtbl.mem g_used_c_names x || Hashtbl.mem l_used_c_names x) in
+    match kind with
+    | Macro ->
+        conflicts_macros x || conflicts_types x || conflicts_other x
+    | Type ->
+        conflicts_macros x || conflicts_types x
+    | Other ->
+        conflicts_macros x || conflicts_other x
+  ) in
   Hashtbl.add c_of_original original_name (unique_c_name, non_modular_renaming && not is_local);
   if is_local then
-    Hashtbl.add l_used_c_names unique_c_name ()
+    Hashtbl.add (used l_used_c_names kind) unique_c_name ()
   else
-    Hashtbl.add g_used_c_names unique_c_name ();
+    Hashtbl.add (used g_used_c_names kind) unique_c_name ();
   unique_c_name
 
 let lookup (env: t) name =
@@ -166,8 +204,12 @@ let lookup (env: t) name =
   Option.map fst (Hashtbl.find_opt c_of_original name)
 
 let clone (env: t) =
-  let c_of_original, used_c_names = env in
-  Hashtbl.copy c_of_original, Hashtbl.copy used_c_names
+  let c_of_original, { types; other; macros } = env in
+  Hashtbl.copy c_of_original, {
+    types = Hashtbl.copy types;
+    other = Hashtbl.copy other;
+    macros = Hashtbl.copy macros;
+  }
 
 let mapping = fst
 
@@ -237,8 +279,6 @@ let strip_leading_underscores name =
     failwith "cannot have a name made of a single underscore";
   String.sub name !i (String.length name - !i)
 
-type kind = Macro | Type | Other
-
 (* Clients feed the result of this to extend -- this is a tentative name that
    may still generate a collision. *)
 let target_c_name ~attempt_shortening ?(kind=Other) lid =
@@ -276,11 +316,11 @@ let target_c_name ~attempt_shortening ?(kind=Other) lid =
   let formatted_name = if kind = Macro then String.uppercase_ascii formatted_name else formatted_name in
   formatted_name, non_modular_renaming
 
-let to_c_name ?kind m lid =
+let to_c_name m lid =
   try
     fst (Hashtbl.find m lid)
   with Not_found ->
     (* Note: this happens for external types which are not retained as DType
        nodes and therefore are not recorded in the initial name-assignment
        phase. *)
-    Idents.to_c_identifier (fst (target_c_name ?kind ~attempt_shortening:false lid))
+    Idents.to_c_identifier (fst (target_c_name ~kind:(snd lid) ~attempt_shortening:false (fst lid)))

--- a/lib/GlobalNames.ml
+++ b/lib/GlobalNames.ml
@@ -316,11 +316,17 @@ let target_c_name ~attempt_shortening ?(kind=Other) lid =
   let formatted_name = if kind = Macro then String.uppercase_ascii formatted_name else formatted_name in
   formatted_name, non_modular_renaming
 
-let to_c_name m lid =
+let to_c_name m (lid, kind) =
   try
-    fst (Hashtbl.find m lid)
+    (* If a regular identifier is not found, it may be the case that it was registered as a macro. *)
+    let lid = if false && not (Hashtbl.mem m (lid, kind)) && kind = Other then lid, Macro else lid, kind in
+    let r = fst (Hashtbl.find m lid) in
+    KPrint.bprintf "%a --> %s\n" plid (fst lid) r;
+    r
   with Not_found ->
     (* Note: this happens for external types which are not retained as DType
        nodes and therefore are not recorded in the initial name-assignment
        phase. *)
-    Idents.to_c_identifier (fst (target_c_name ~kind:(snd lid) ~attempt_shortening:false (fst lid)))
+    let r = Idents.to_c_identifier (fst (target_c_name ~kind ~attempt_shortening:false lid)) in
+    KPrint.bprintf "%a !!! %s\n" plid lid r;
+    r

--- a/lib/Output.ml
+++ b/lib/Output.ml
@@ -245,7 +245,7 @@ let write_def m c_files =
       List.iter (function
         | Ast.DFunction (_, flags, _, _, _, name, _, _)
           when not (List.mem Common.Private flags) ->
-            let name = GlobalNames.to_c_name m name in
+            let name = GlobalNames.to_c_name m (name, Other) in
             KPrint.bfprintf oc "  %s\n" name
         | _ -> ()
       ) decls
@@ -256,7 +256,9 @@ let write_renamings (m: GlobalNames.mapping) =
   create_subdir "clients";
   let dst = in_tmp_dir "clients/krmlrenamings.h" in
   with_open_out_bin dst (fun oc ->
-    Hashtbl.iter (fun original_name (new_name, non_modular_renaming) ->
+    (* Another imprecision here: this strategy won't work if two names live in `Type` and `Other`
+       namespaces, *and* share the same name, *and* are both subject to non-modular renamings. *)
+    Hashtbl.iter (fun (original_name, _) (new_name, non_modular_renaming) ->
       (* Note: there is a slight imprecision here. If the original name WOULD
          HAVE BEEN renamed because of a name collision, then this renaming map
          will be incorrect. We would to track two maps in GlobalNames, the

--- a/lib/Simplify.ml
+++ b/lib/Simplify.ml
@@ -1520,9 +1520,9 @@ class scope_helpers = object (self)
     let is_private = self#is_private_scope flags lident in
     let local_scope = Hashtbl.find local_scopes current_file in
     let attempt_shortening = is_private && not is_external in
-    let target = GlobalNames.target_c_name ~attempt_shortening ~kind lident in
+    let target = GlobalNames.target_c_name ~kind ~attempt_shortening lident in
     (* KPrint.bprintf "%a --> %s\n" plid lident (fst target); *)
-    let c_name = GlobalNames.extend global_scope local_scope is_private lident target in
+    let c_name = GlobalNames.extend global_scope local_scope is_private (lident, kind) target in
     if not is_private then
       Hashtbl.add original_of_c_name c_name lident
 end
@@ -1554,7 +1554,7 @@ let record_toplevel_names = object (self)
     if not (Hashtbl.mem forward name) then
       self#record env ~is_type:true ~is_external:false flags name;
     match def with
-    | Enum lids -> List.iter (fun (lid, _) -> self#record env ~is_type:true ~is_external:false flags lid) lids
+    | Enum lids -> List.iter (fun (lid, _) -> self#record env ~is_type:false ~is_external:false flags lid) lids
     | Forward _ -> Hashtbl.add forward name ()
     | _ -> ()
 end


### PR DESCRIPTION
krml previously considered that all (global) names live in a single namespace, meaning that there were spurious name collisions (for instance, between the case of an enum and a type) as well as missed collisions (because things that are sent to macros end up colliding with everything else)

this overhauls the name management infrastructure (the GlobalNames module) to distinguish three pseudo-namespaces:
- macros
- types
- other declarations (value namespace)

macros conflict with types and other declarations, while type and other declarations do not conflict with each other

this solves a problem exercised by Eurydice while trying to extract Rust's core::fmt::rt namespace