### PR TITLE
Option length for arrays in CStar and C11 for flexible array member

### DIFF
--- a/lib/C11.ml
+++ b/lib/C11.ml
@@ -40,7 +40,7 @@ and declarator_and_inits =
 and declarator =
   | Ident of ident
   | Pointer of qualifier list * declarator
-  | Array of qualifier list * declarator * expr
+  | Array of qualifier list * declarator * expr option
   | Function of calling_convention option * declarator * params
 
 and expr =

--- a/lib/CStar.ml
+++ b/lib/CStar.ml
@@ -113,7 +113,7 @@ and typ =
   | Pointer of typ
   | Void
   | Qualified of lident
-  | Array of typ * expr
+  | Array of typ * expr option
   | Function of calling_convention option * typ * typ list
       (** Return type, arguments *)
   | Bool

--- a/lib/PrintC.ml
+++ b/lib/PrintC.ml
@@ -129,7 +129,8 @@ and p_type_declarator d =
     | Ident n ->
         string n
     | Array (qs, d, s) ->
-        p_noptr d ^^ lbracket ^^ p_qualifiers_break qs ^^ p_expr s ^^ rbracket
+        let s = match s with Some s -> p_expr s | None -> empty in
+        p_noptr d ^^ lbracket ^^ p_qualifiers_break qs ^^ s ^^ rbracket
     | Function (cc, d, params) ->
         let cc = match cc with Some cc -> print_cc cc ^^ break1 | None -> empty in
         let params =


### PR DESCRIPTION
Comes from the discussion in the PR  [Translating rust array type [T;C] into struct arr { T[C] data; } #252](https://github.com/AeneasVerif/eurydice/pull/252) for Eurydice. @msprotz  