### PR TITLE
Fix issue uncovered by AeneasVerif/eurydice#252

### DIFF
--- a/lib/AstToCStar.ml
+++ b/lib/AstToCStar.ml
@@ -841,8 +841,8 @@ and mk_return_type env = function
       mk_type_def env t
   | TCgArray _ ->
       CStar.Qualified (["Eurydice"], "error_t_cg_array")
-  | TCgApp _ ->
-      fatal_error "Internal failure: TCgApp not desugared here"
+  | (TCgApp _) as t ->
+      Warn.fatal_error "Internal failure: TCgApp not desugared here %a" ptyp t
   | TPoly _ ->
       fatal_error "Internal failure: TPoly not desugared here"
 


### PR DESCRIPTION
Various small fixes:
- incorrect order of substitutions
- incorrect recursion that still allowed a partially-monomorphized type, this was not supposed to happen

This required refining the criterion for determining whether an argument is a closed term or not.

CC @Lin23299 