### PR TITLE
Nit: more expressive error instead of assert false

### DIFF
--- a/lib/Helpers.ml
+++ b/lib/Helpers.ml
@@ -440,7 +440,7 @@ let rec is_initializer_constant e =
 
 let assert_tlid t =
   (* We only have nominal typing for variants. *)
-  match t with TQualified lid -> lid | _ -> assert false
+  match t with TQualified lid -> lid | _ -> Warn.fatal_error "Not a tlid: %a" ptyp t
 
 let assert_tbuf t =
   match t with TBuf (t, _) -> t | t -> Warn.fatal_error "Not a buffer: %a" ptyp t


### PR DESCRIPTION
I hit this in some weird combination of noextract / inline_for_extraction attributes. Just making the error more informative.