### PR TITLE
Added case for compound literal in [trim_trailing_zeros]

### DIFF
--- a/lib/CStarToC11.ml
+++ b/lib/CStarToC11.ml
@@ -239,6 +239,7 @@ let rec is_zero = function
 let rec trim_trailing_zeros l =
   match l with
   | Initializer [] -> Initializer []
+  | InitExpr (CompoundLiteral (_, l)) -> Initializer (List.map trim_trailing_zeros (chop_zeros l))
   | InitExpr e -> InitExpr e
   | Designated (d, init) -> Designated (d, trim_trailing_zeros init)
   | Initializer l -> Initializer (List.map trim_trailing_zeros (chop_zeros l))


### PR DESCRIPTION
Comes from eurydice PR https://github.com/AeneasVerif/eurydice/pull/252. 