### PR TITLE
Use { 0 } for arrays within compound literals too

### DIFF
--- a/lib/CStarToC11.ml
+++ b/lib/CStarToC11.ml
@@ -1166,7 +1166,7 @@ and mk_compound_literal m name fields =
       ])
   | _ ->
       (* TODO really properly specify C's type_name! *)
-      CompoundLiteral (([], Named name, Ident ""), fields_as_initializer_list m fields)
+      CompoundLiteral (([], Named name, Ident ""), List.map trim_trailing_zeros (fields_as_initializer_list m fields))
 
 and struct_as_initializer m = function
   | Struct (_, fields) ->


### PR DESCRIPTION
Via aeneasverif/eurydice#252 -- this improves code quality even further

https://github.com/cryspen/libcrux/commit/4405730c2d51fe78ba0579a728875e36f997c1b6

CC @franziskuskiefer for the effect on libcrux