### PR TITLE
CI: Use OCaml 5.3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup ocaml
         uses: ocaml/setup-ocaml@v3
         with:
-           ocaml-compiler: 4.14.2
+           ocaml-compiler: 5.3.0
 
       - uses: actions/checkout@master
         with:


### PR DESCRIPTION
There is currently a problem with OCaml's pprintast/ppxlib in that it generates "raw identifiers" like `\#module` which are not valid in OCaml below 5.2.0

See https://github.com/ocaml/opam-repository/pull/28610#issuecomment-3362301901 for some discussion.

I think this will be fixed upstream, but bumping to OCaml 5.3.0 seems useful anyway. (We can also work around it by using `" module"` instead of `"module"` in lib/GenCtypes.ml, but that's nasty.)

PS. I looked at adding a Nix CI, but adding `checkPhase = "make test"` didn't work for me. I also have no idea how to change the dependencies such as this OCaml version, so I would leave changing the CI to someone else.